### PR TITLE
proof-of-concet support of custom image survey

### DIFF
--- a/ipyaladin/aladin_widget.py
+++ b/ipyaladin/aladin_widget.py
@@ -1,5 +1,5 @@
 from ipywidgets import (widgets)
-from traitlets import (Float, Unicode, Bool, List, Dict, default)
+from traitlets import (Float, Unicode, Bool, List, Dict, Union, default)
 
 
 
@@ -25,7 +25,8 @@ class Aladin(widgets.DOMWidget):
     fov = Float(60).tag(sync=True, o=True)
     target = Unicode("0 +0").tag(sync=True, o=True)
     coo_frame = Unicode("J2000").tag(sync=True, o=True) 
-    survey = Unicode("P/DSS2/color").tag(sync=True, o=True)
+    survey = Union([Unicode(), Dict()],
+                   default_value="P/DSS2/color").tag(sync=True, o=True)
     overlay_survey = Unicode('').tag(sync=True, o=True)
     overlay_survey_opacity = Float(0.0).tag(sync=True, o=True)
 

--- a/js/src/jupyter-aladin.js
+++ b/js/src/jupyter-aladin.js
@@ -157,7 +157,15 @@ var ViewAladin = widgets.DOMWidgetView.extend({
             that.al.setFrame(that.model.get('coo_frame'));
         }, this);
         this.listenTo(this.model, 'change:survey', function () {
-            that.al.setImageSurvey(that.model.get('survey'));
+            var s = that.model.get('survey');
+            if (s.constructor == Object) {
+                s = that.al.createImageSurvey(s.hips_id,
+                                              s.hips_name,
+                                              s.base_url,
+                                              s.frame, s.max_order,
+                                              {imgFormat: s.image_format});
+            }
+            that.al.setImageSurvey(s);
         }, this);
         this.listenTo(this.model, 'change:overlay_survey', function () {
             that.al.setOverlayImageLayer(that.model.get('overlay_survey'));


### PR DESCRIPTION
This PR adds a support for a custom image survey (#19). The way how it handles the input is quite prone to errors and needs improvement. Since @[tboch](https://github.com/tboch) mentioned that he will add this feature, I wanted to get some early feedback (or current status) if possible.

```python
survey = dict(hips_id="2MASS", hips_name="2MASS", base_url="http://alasky.u-strasbg.fr/2MASS/K",
              frame="equatorial", max_order=9, image_format="jpg")
aladin.survey = survey
```
