### PR TITLE
Jupyterlab support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ To install use pip:
 Then, make sure to enable widgetsnbextension:
 
     $ jupyter nbextension enable --py widgetsnbextension
-    
+
 Finally, enable ipyaladin:
 
     $ jupyter nbextension enable --py --sys-prefix ipyaladin
 
 There is also an experimental conda package that can be installed with:
 
-    $  conda install -c tboch ipyaladin 
+    $  conda install -c tboch ipyaladin
 
 
 For a development installation (requires npm) you can either do:
@@ -63,5 +63,7 @@ Running in JupyterLab (experimental)
 To enable ipyaladin in JupyterLab:
 
     $ git clone https://github.com/cds-astro/ipyaladin
+    $ cd ipyaladin
+    $ python -m pip install [-e] .
     $ cd ipyaladin/js
-    $ jupyter labextension install
+    $ jupyter labextension install @jupyter-widgets/jupyterlab-manager .

--- a/README.md
+++ b/README.md
@@ -67,3 +67,5 @@ To enable ipyaladin in JupyterLab:
     $ python -m pip install [-e] .
     $ cd ipyaladin/js
     $ jupyter labextension install @jupyter-widgets/jupyterlab-manager .
+
+Now when you start JupyterLab you will be prompted to rebuild the extension. Choose 'Rebuild' and all the ipyaladin examples should now work.

--- a/js/src/extension.js
+++ b/js/src/extension.js
@@ -8,7 +8,7 @@ if (window.require) {
         map: {
             "*" : {
                 "ipyaladin": "nbextensions/ipyaladin/index",
-                "jupyter-js-widgets": "nbextensions/jupyter-js-widgets/extension"
+                // "jupyter-widgets": "nbextensions/jupyter-widgets/extension"
             }
         }
     });

--- a/js/src/jupyter-aladin.js
+++ b/js/src/jupyter-aladin.js
@@ -14,7 +14,7 @@ var aladin_lib = require('./aladin_lib.js');
 // Allow us to use the DOMWidgetView base class for our models/views.
 // Additionnaly, this is where we put by default all the external libraries
 // fetched by using webpack (see webpack.config.js file).
-var widgets = require('jupyter-js-widgets');
+var widgets = require('@jupyter-widgets/base');
 var _ = require("underscore");
 
 
@@ -38,10 +38,10 @@ var CSS_Loader= ({
 
 /**
  * Definition of the AladinLite widget's model in the browser
- * Useful documentation about the widget's global implementation : 
+ * Useful documentation about the widget's global implementation :
  * (from http://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Custom.html)
  * The IPython widget framework front end relies heavily on Backbone.js.
- * Backbone.js is an MVC (model view controller) framework. 
+ * Backbone.js is an MVC (model view controller) framework.
  * Widgets defined in the back end are automatically synchronized with generic Backbone.js
  * models in the front end.
  * The traitlets are added to the front end instance automatically on first state push.
@@ -129,7 +129,7 @@ var ViewAladin = widgets.DOMWidgetView.extend({
             }else{
                 that.target_py= false;
             }
-            
+
         });
     },
 
@@ -174,7 +174,7 @@ var ViewAladin = widgets.DOMWidgetView.extend({
         this.listenTo(this.model, 'change:moc_from_URL_flag', function(){
             that.al.addMOC(aladin_lib.A.MOCFromURL(that.model.get('moc_URL'), that.model.get('moc_options')));
         }, this);
-        
+
         this.listenTo(this.model, 'change:moc_from_dict_flag', function(){
             that.al.addMOC(aladin_lib.A.MOCFromJSON(that.model.get('moc_dict'), that.model.get('moc_options')));
         }, this);
@@ -263,7 +263,7 @@ module.exports = {
     ModelAladin : ModelAladin
 };
 
-/** 
+/**
 TODO:
 !!!: it seems that the rendering bug that occurs when the widget is displayed on full-screen is back......
 load AladinLite library from http...

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = [
         module: {
             loaders: loaders
         },
-        externals: ['jupyter-js-widgets']
+        externals: ['jupyter-widgets']
     },
     /*{// Embeddable ipyaladin bundle
      //
@@ -66,9 +66,9 @@ module.exports = [
         module: {
             loaders: loaders
         },
-        externals: ['jupyter-js-widgets']
+        externals: ['jupyter-widgets']
     }*/
-    // test 
+    // test
     /*{
         entry: './src/embed.js',
         output: {
@@ -81,7 +81,7 @@ module.exports = [
         module: {
             loaders: loaders
         },
-        externals: ['jupyter-js-widgets']
+        externals: ['jupyter-widgets']
     }*/
     /*{
         entry: './src/embed.js',
@@ -97,6 +97,6 @@ module.exports = [
         module: {
             loaders: loaders
         },
-        externals: ['jupyter-js-widgets']
+        externals: ['jupyter-widgets']
     }*/
 ];


### PR DESCRIPTION
This PR replaces deprecated calls to `jupyter-js-widgets` with `jupyter-widgets` and `@jupyter-widgets/base` (see https://www.npmjs.com/package/jupyter-js-widgets?activeTab=versions). Also updates README with instructions for building and installing the package and JupyterLab extension.

Tested on JupyterLab version 3.1.7. All examples in `ipyaladin/examples` work well. 