### PR TITLE
Enable custom HiPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ To install use pip:
 Then, make sure to enable widgetsnbextension:
 
     $ jupyter nbextension enable --py widgetsnbextension
-    
+
 Finally, enable ipyaladin:
 
     $ jupyter nbextension enable --py --sys-prefix ipyaladin
 
 There is also an experimental conda package that can be installed with:
 
-    $  conda install -c tboch ipyaladin 
+    $  conda install -c tboch ipyaladin
 
 
 For a development installation (requires npm) you can either do:
@@ -63,5 +63,7 @@ Running in JupyterLab (experimental)
 To enable ipyaladin in JupyterLab:
 
     $ git clone https://github.com/cds-astro/ipyaladin
+    $ cd ipyaladin
+    $ python -m pip install [-e] .
     $ cd ipyaladin/js
-    $ jupyter labextension install
+    $ jupyter labextension install @jupyter-widgets/jupyterlab-manager .

--- a/README.md
+++ b/README.md
@@ -67,3 +67,5 @@ To enable ipyaladin in JupyterLab:
     $ python -m pip install [-e] .
     $ cd ipyaladin/js
     $ jupyter labextension install @jupyter-widgets/jupyterlab-manager .
+
+Now when you start JupyterLab you will be prompted to rebuild the extension. Choose 'Rebuild' and all the ipyaladin examples should now work.

--- a/ipyaladin/aladin_widget.py
+++ b/ipyaladin/aladin_widget.py
@@ -17,14 +17,14 @@ class Aladin(widgets.DOMWidget):
     _model_module_version = Unicode('0.1.9').tag(sync=True)
 
 
-    # Aladin options must be declared here (as python class's attributes), 
+    # Aladin options must be declared here (as python class's attributes),
     # so that they can be synchronized from the python side to the javascript side
     # Default values are overwritten by values passed to the class's constructor
-    
+
     # only theses 4 values are actually updated on one side when they change on the other
     fov = Float(60).tag(sync=True, o=True)
     target = Unicode("0 +0").tag(sync=True, o=True)
-    coo_frame = Unicode("J2000").tag(sync=True, o=True) 
+    coo_frame = Unicode("J2000").tag(sync=True, o=True)
     survey = Unicode("P/DSS2/color").tag(sync=True, o=True)
     overlay_survey = Unicode('').tag(sync=True, o=True)
     overlay_survey_opacity = Float(0.0).tag(sync=True, o=True)
@@ -48,6 +48,13 @@ class Aladin(widgets.DOMWidget):
     options = List(trait=Unicode).tag(sync=True)
 
     # the following values are used in the classe's functions
+
+    # values used in the add_catalog_from_URL function
+    hips_URL = Unicode('').tag(sync=True)
+    hips_id = Unicode('').tag(sync=True)
+    hips_name = Unicode('').tag(sync=True)
+    hips_options = Dict().tag(sync=True)
+    hips_from_URL_flag = Bool(True).tag(sync=True)
 
     # values used in the add_catalog_from_URL function
     votable_URL = Unicode('').tag(sync=True)
@@ -89,7 +96,7 @@ class Aladin(widgets.DOMWidget):
     # values used in the get_JPEG_thumbnail function
     thumbnail_flag = Bool(True).tag(sync=True)
 
-    # 
+    #
     color_map_name = Unicode('').tag(sync=True)
     color_map_flag = Bool(True).tag(sync=True)
 
@@ -115,8 +122,19 @@ class Aladin(widgets.DOMWidget):
     # the role of a flag, whose change in value trigger a listener in the js side,
     # who can then execute the function whose parameters are passed as trailets in its python equivalent
 
+    def add_hips_from_URL(self, hips_URL, hips_id, hips_name, hips_options={}):
+        """ load a VOTable table from an url and load its data into the widget
+            Args:
+                votable_URL: string url
+                votable_options: dictionary object"""
+        self.hips_URL= hips_URL
+        self.hips_id= hips_id
+        self.hips_name= hips_name
+        self.hips_options= hips_options
+        self.hips_from_URL_flag= not self.hips_from_URL_flag
+
     def add_catalog_from_URL(self, votable_URL, votable_options={}):
-        """ load a VOTable table from an url and load its data into the widget 
+        """ load a VOTable table from an url and load its data into the widget
             Args:
                 votable_URL: string url
                 votable_options: dictionary object"""
@@ -137,7 +155,7 @@ class Aladin(widgets.DOMWidget):
         """ load a MOC from a dict object and display it in Aladin Lite widget
             Arguments:
             moc_dict: the dict containing the MOC cells. Key are the HEALPix orders,
-                      values are the pixel indexes, eg: {"1":[1,2,4], "2":[12,13,14,21,23,25]} 
+                      values are the pixel indexes, eg: {"1":[1,2,4], "2":[12,13,14,21,23,25]}
             moc_options: dictionary object"""
         self.moc_dict = moc_dict
         self.moc_options = moc_options
@@ -158,7 +176,7 @@ class Aladin(widgets.DOMWidget):
         # theses library must be installed, and are used in votable operations
         # http://www.astropy.org/
         import astropy
-        
+
         table_array = table.__array__()
         self.table_keys= table.keys()
         table_columns= []
@@ -193,7 +211,7 @@ class Aladin(widgets.DOMWidget):
     def add_listener(self, listener_type, callback):
         """ add a listener to the widget
             Args:
-                listener_type: string that can either be 'objectHovered' or 'objClicked' 
+                listener_type: string that can either be 'objectHovered' or 'objClicked'
                 callback: python function"""
         self.listener_type= listener_type
         if listener_type == 'objectHovered':

--- a/js/src/extension.js
+++ b/js/src/extension.js
@@ -8,7 +8,7 @@ if (window.require) {
         map: {
             "*" : {
                 "ipyaladin": "nbextensions/ipyaladin/index",
-                "jupyter-js-widgets": "nbextensions/jupyter-js-widgets/extension"
+                // "jupyter-widgets": "nbextensions/jupyter-widgets/extension"
             }
         }
     });

--- a/js/src/jupyter-aladin.js
+++ b/js/src/jupyter-aladin.js
@@ -167,6 +167,10 @@ var ViewAladin = widgets.DOMWidgetView.extend({
         }, this);
 
         // Model's functions parameters listeners
+        this.listenTo(this.model, 'change:hips_from_URL_flag', function(){
+            that.al.setBaseImageLayer(aladin_lib.A.imageLayer(that.model.get('hips_id'), that.model.get('hips_name'), that.model.get('hips_URL'), that.model.get('hips_options')));
+        }, this);
+
         this.listenTo(this.model, 'change:votable_from_URL_flag', function(){
             that.al.addCatalog(aladin_lib.A.catalogFromURL(that.model.get('votable_URL'), that.model.get('votable_options')));
         }, this);

--- a/js/src/jupyter-aladin.js
+++ b/js/src/jupyter-aladin.js
@@ -168,7 +168,20 @@ var ViewAladin = widgets.DOMWidgetView.extend({
 
         // Model's functions parameters listeners
         this.listenTo(this.model, 'change:hips_from_URL_flag', function(){
-            that.al.setBaseImageLayer(aladin_lib.A.imageLayer(that.model.get('hips_id'), that.model.get('hips_name'), that.model.get('hips_URL'), that.model.get('hips_options')));
+            let hips_max_order = 9;
+            try {
+              hips_max_order = parseInt(that.model.get('hips_max_order'));
+            } catch(err){
+              console.log(`Could not convert HIPS max order to an integer defaulting to ${hips_max_order}`);
+            }
+            that.al.setBaseImageLayer(that.al.createImageSurvey(
+              that.model.get('hips_id'),
+              that.model.get('hips_name'),
+              that.model.get('hips_URL'),
+              that.model.get('hips_frame'),
+              hips_max_order,
+              that.model.get('hips_options')
+            ));
         }, this);
 
         this.listenTo(this.model, 'change:votable_from_URL_flag', function(){

--- a/js/src/jupyter-aladin.js
+++ b/js/src/jupyter-aladin.js
@@ -14,7 +14,7 @@ var aladin_lib = require('./aladin_lib.js');
 // Allow us to use the DOMWidgetView base class for our models/views.
 // Additionnaly, this is where we put by default all the external libraries
 // fetched by using webpack (see webpack.config.js file).
-var widgets = require('jupyter-js-widgets');
+var widgets = require('@jupyter-widgets/base');
 var _ = require("underscore");
 
 
@@ -38,10 +38,10 @@ var CSS_Loader= ({
 
 /**
  * Definition of the AladinLite widget's model in the browser
- * Useful documentation about the widget's global implementation : 
+ * Useful documentation about the widget's global implementation :
  * (from http://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Custom.html)
  * The IPython widget framework front end relies heavily on Backbone.js.
- * Backbone.js is an MVC (model view controller) framework. 
+ * Backbone.js is an MVC (model view controller) framework.
  * Widgets defined in the back end are automatically synchronized with generic Backbone.js
  * models in the front end.
  * The traitlets are added to the front end instance automatically on first state push.
@@ -129,7 +129,7 @@ var ViewAladin = widgets.DOMWidgetView.extend({
             }else{
                 that.target_py= false;
             }
-            
+
         });
     },
 
@@ -174,7 +174,7 @@ var ViewAladin = widgets.DOMWidgetView.extend({
         this.listenTo(this.model, 'change:moc_from_URL_flag', function(){
             that.al.addMOC(aladin_lib.A.MOCFromURL(that.model.get('moc_URL'), that.model.get('moc_options')));
         }, this);
-        
+
         this.listenTo(this.model, 'change:moc_from_dict_flag', function(){
             that.al.addMOC(aladin_lib.A.MOCFromJSON(that.model.get('moc_dict'), that.model.get('moc_options')));
         }, this);
@@ -263,7 +263,7 @@ module.exports = {
     ModelAladin : ModelAladin
 };
 
-/** 
+/**
 TODO:
 !!!: it seems that the rendering bug that occurs when the widget is displayed on full-screen is back......
 load AladinLite library from http...

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = [
         module: {
             loaders: loaders
         },
-        externals: ['jupyter-js-widgets']
+        externals: ['jupyter-widgets']
     },
     /*{// Embeddable ipyaladin bundle
      //
@@ -66,9 +66,9 @@ module.exports = [
         module: {
             loaders: loaders
         },
-        externals: ['jupyter-js-widgets']
+        externals: ['jupyter-widgets']
     }*/
-    // test 
+    // test
     /*{
         entry: './src/embed.js',
         output: {
@@ -81,7 +81,7 @@ module.exports = [
         module: {
             loaders: loaders
         },
-        externals: ['jupyter-js-widgets']
+        externals: ['jupyter-widgets']
     }*/
     /*{
         entry: './src/embed.js',
@@ -97,6 +97,6 @@ module.exports = [
         module: {
             loaders: loaders
         },
-        externals: ['jupyter-js-widgets']
+        externals: ['jupyter-widgets']
     }*/
 ];


### PR DESCRIPTION
Allows a properly served HiPS map to be retrieved from a user-specified URL e.g. https://hips.astron.nl/ASTRON/P/lotss_dr2_high/ and displayed via JupyterLab interface.