### PR TITLE
Prepare release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0]
+
 ### Added
 
 - attribute `__aladin_lite_version__` added to point to the corresponding Aladin Lite released version
@@ -27,15 +29,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `clicked_object` was not properly updated after a click
 - Fix asynchronous update for the `target` property (#80)
+- some options were not accepted in snake_case anymore in `add_moc` and in `add_catalog_from_url` (#82)
 
 ### Changed
 
 - Change the jslink target trait from `target` to `shared_target` (#80)
 - Change the jslink fov trait from `fov` to `shared_fov` (#83)
-- Deprecate the `add_listener` method for a preferred use of `set_listener` method (#82)
 - Upgrade Aladin Lite version to 3.4.1-beta (#88)
 - Add support for list of strings in `add_overlay_from_stcs` (#88)
+
+### Deprecated
+
 - Deprecate `add_overlay_from_stcs` in favor of `add_graphic_overlay_from_stcs` (#88)
+- Deprecate the `add_listener` method for a preferred use of `set_listener` method (#82)
 
 ## [0.3.0]
 

--- a/README.md
+++ b/README.md
@@ -56,21 +56,21 @@ Ipyaladin brings [Aladin Lite](https://github.com/cds-astro/aladin-lite) into no
 
 Correspondence table between ipyaladin versions and Aladin Lite versions:
 
-| ipyaladin  | Aladin-Lite |
-| ---------- | ----------- |
-| 0.3.0      | 3.3.3-dev   |
-| unreleased | 3.4.1-beta  |
+| ipyaladin | Aladin-Lite |
+| --------- | ----------- |
+| 0.3.0     | 3.3.3-dev   |
+| 0.4.0     | 3.4.4-beta  |
 
 > [!TIP]
 > This can always be read like so
 >
 > ```python
 > from ipyaladin import __version__, __aladin_lite_version__
-> print("version:", __version__, "running aladin lite:", __aladin_lite_version__)
+> print("version:", __version__, "running Aladin Lite:", __aladin_lite_version__)
 > ```
 >
 > ```
-> version: unreleased running aladin lite: 3.4.1-beta
+> version: 0.4.0 running Aladin Lite: 3.4.4-beta
 > ```
 
 ## Acknowledging ipyaladin

--- a/examples/2_Base_Commands.ipynb
+++ b/examples/2_Base_Commands.ipynb
@@ -72,11 +72,13 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "aladin.target"
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin.target"
+   ]
   },
   {
    "cell_type": "code",
@@ -118,7 +120,7 @@
    },
    "outputs": [],
    "source": [
-    "aladin.coo_frame = \"J2000d\""
+    "aladin.coo_frame = \"ICRSd\"  # ICRS, and angles expressed in degrees"
    ]
   },
   {
@@ -131,30 +133,38 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "Some commands can be used with astropy objects"
+   "metadata": {},
+   "source": [
+    "Some commands can be used with astropy objects"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "from astropy.coordinates import Angle, SkyCoord"
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.coordinates import Angle, SkyCoord"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "aladin.target = SkyCoord(\"12h00m00s\", \"-30d00m00s\", frame=\"icrs\")"
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin.target = SkyCoord(\"12h00m00s\", \"-30d00m00s\", frame=\"icrs\")"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "aladin.fov = Angle(5, \"deg\")"
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin.fov = Angle(5, \"deg\")"
+   ]
   }
  ],
  "metadata": {
@@ -173,7 +183,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.8"
   },
   "vscode": {
    "interpreter": {

--- a/js/aladin_lite.js
+++ b/js/aladin_lite.js
@@ -1,3 +1,3 @@
-import A from "https://esm.sh/aladin-lite@3.4.1-beta";
+import A from "https://esm.sh/aladin-lite@3.4.4-beta";
 
 export default A;

--- a/js/models/message_handler.js
+++ b/js/models/message_handler.js
@@ -63,8 +63,10 @@ export default class MessageHandler {
           );
           break;
         case "line":
+          // remove default lineWidth when we switch to AL > 3.4.4
+          region.options.lineWidth = region.options.lineWidth || 3;
           overlay.add(
-            A.line(
+            A.vector(
               infos.ra1,
               infos.dec1,
               infos.ra2,

--- a/src/ipyaladin/__about__.py
+++ b/src/ipyaladin/__about__.py
@@ -1,2 +1,2 @@
-__version__ = "0.4.0-beta"
-__aladin_lite_version__ = "3.4.1-beta"
+__version__ = "0.4.0"
+__aladin_lite_version__ = "3.4.4-beta"


### PR DESCRIPTION
- maint: bump AL version
- fix: A.line was removed from public AL API in favor of A.vector