### PR TITLE
prepare 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2]
+
 ### Fixed
 
 - in `add_marker`, markers don't use the default icon anymore. Do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix wrapper `widget_should_be_loaded` that was over-writing the methods documentation
+  [#130]
+
 ## [0.5.1]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- in `add_marker`, markers don't use the default icon anymore. Do
+  `use_marker_default_icon = True` in `add_marker` to recover the previous
+  behavior [#129]
 - Fix wrapper `widget_should_be_loaded` that was over-writing the methods documentation
   [#130]
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Correspondence table between ipyaladin versions and Aladin Lite versions:
 | ipyaladin  | Aladin-Lite |
 | ---------- | ----------- |
 | Unreleased | 3.5.1-beta  |
+| 0.5.2      | 3.5.1-beta  |
 | 0.5.1      | 3.5.1-beta  |
 | 0.5.0      | 3.5.1-beta  |
 | 0.4.0      | 3.4.4-beta  |

--- a/js/models/message_handler.js
+++ b/js/models/message_handler.js
@@ -21,6 +21,7 @@ export default class MessageHandler {
     for (const marker of pythonMarkers) {
       markers.push(
         A.marker(marker["lon"], marker["lat"], {
+          useMarkerDefaultIcon: options["useMarkerDefaultIcon"] | false,
           popupTitle: marker["title"],
           popupDesc: marker["description"],
         }),

--- a/src/ipyaladin/__about__.py
+++ b/src/ipyaladin/__about__.py
@@ -1,2 +1,2 @@
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 __aladin_lite_version__ = "3.5.1-beta"

--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -696,7 +696,7 @@ class Aladin(anywidget.AnyWidget):
         warnings.warn(
             "add_moc_from_URL is replaced by add_moc that detects automatically"
             "that the MOC was given as an URL."
-            "This will be removed in version 1.0.0 (coming afer 0.5.1).",
+            "This will be removed in version 1.0.0 (coming after 0.5).",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -723,7 +723,7 @@ class Aladin(anywidget.AnyWidget):
         warnings.warn(
             "add_moc_from_dict is replaced by add_moc that detects automatically"
             "that the MOC was given as a dictionary."
-            "This will be removed in version 1.0.0 (coming afer 0.5.1).",
+            "This will be removed in version 1.0.0 (coming after 0.5).",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -855,7 +855,7 @@ class Aladin(anywidget.AnyWidget):
         warnings.warn(
             "'add_overlay_from_stcs' is deprecated, "
             "use 'add_graphic_overlay_from_stcs' instead. "
-            "This will be removed in version 1.0.0 (coming afer 0.5.1).",
+            "This will be removed in version 1.0.0 (coming after 0.5).",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -936,7 +936,7 @@ class Aladin(anywidget.AnyWidget):
         """
         warnings.warn(
             "rectangular_selection is deprecated, use selection('rectangle') instead"
-            "This will be removed in version 1.0.0 (coming afer 0.5.1).",
+            "This will be removed in version 1.0.0 (coming after 0.5).",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -990,7 +990,7 @@ class Aladin(anywidget.AnyWidget):
         """
         warnings.warn(
             "add_listener is deprecated, use set_listener instead"
-            "This will be removed in version 1.0.0 (coming afer 0.5.1).",
+            "This will be removed in version 1.0.0 (coming after 0.5).",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -6,9 +6,10 @@ It allows to display astronomical images and catalogs in an interactive way.
 """
 
 from collections.abc import Callable
+import functools
+from json import JSONDecodeError
 import io
 import pathlib
-from json import JSONDecodeError
 from pathlib import Path
 import time
 from typing import ClassVar, Dict, Final, List, Optional, Tuple, Union
@@ -74,12 +75,12 @@ SupportedRegion = Union[
 ]
 
 
-def widget_should_be_loaded(func: Callable) -> Callable:
+def widget_should_be_loaded(function: Callable) -> Callable:
     """Check if the widget is ready to execute a function.
 
     Parameters
     ----------
-    func : Callable
+    function : Callable
         The function to decorate.
 
     Returns
@@ -89,6 +90,7 @@ def widget_should_be_loaded(func: Callable) -> Callable:
 
     """
 
+    @functools.wraps(function)
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         """Check if the widget is ready to execute a function.
 
@@ -114,7 +116,7 @@ def widget_should_be_loaded(func: Callable) -> Callable:
             time.sleep(duration)
             # set ready to True to avoid waiting twice
             self._is_loaded = True
-        return func(self, *args, **kwargs)
+        return function(self, *args, **kwargs)
 
     return wrapper
 


### PR DESCRIPTION
This merges two bug fixes:
- markers don't use circles shape all the time anymore (can now take all the shapes from sources)
- docstrings of wrapped functions appear again