### PR TITLE
Addressed issue in ipyaladin when height=-1 is provided to Aladin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - footprints will now appear immediately after adding them, without requiring an other
   event (fixed in https://github.com/cds-astro/aladin-lite/pull/218)
+- when Aladin is initialized with `Aladin(height=-1)` it correctly occupy 100% of its
+  `<div>` container [#142]
 
 ## [0.5.2]
 

--- a/js/widget.css
+++ b/js/widget.css
@@ -10,3 +10,11 @@
 .aladin-widget .aladin-measurement-div {
   max-height: 100px;
 }
+
+.lm-Widget.aladin-lite-lm-container {
+  /* Style fix for the aladin widget container.
+     The aladin widget is not being able to render to 100% height when initialized with
+     height=-1 in the constructor
+     see widget.js:13 */
+  height: 100%;
+}

--- a/js/widget.js
+++ b/js/widget.js
@@ -9,6 +9,9 @@ import {
 import A from "./aladin_lite";
 
 function initAladinLite(model, el) {
+  // Add 'aladin-lite-lm-container' class to the div container to apply the CSS styles in widget.css
+  el.classList.add("aladin-lite-lm-container");
+
   setDivNumber(divNumber + 1);
   let initFromPython = model.get("_init_options");
   let initOptions = {};

--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -270,21 +270,15 @@ class Aladin(anywidget.AnyWidget):
         -------
         int
             The height of the widget in pixels.
+            Setting the height to -1 will expand the widget at 100% height of its
+            container. This is generally a bad idea in a notebook but can be usefull
+            for dashbord applications.
+            The default height is 400 pixels.
         """
         return self._height
 
     @height.setter
     def height(self, height: int) -> None:
-        """Set the height of the widget.
-
-        Parameters
-        ----------
-        height : int
-            The height of the widget in pixels.
-            Setting the height to -1 will expand the widget at 100% height of its
-            container. This is generally a bad idea in a notebook but can be usefull
-            for dashbord applications.
-        """
         if np.isclose(self._height, height):
             return
         self._wcs = {}

--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -270,15 +270,21 @@ class Aladin(anywidget.AnyWidget):
         -------
         int
             The height of the widget in pixels.
-            Setting the height to -1 will expand the widget at 100% height of its
-            container. This is generally a bad idea in a notebook but can be usefull
-            for dashbord applications.
-            The default height is 400 pixels.
         """
         return self._height
 
     @height.setter
     def height(self, height: int) -> None:
+        """Set the height of the widget.
+
+        Parameters
+        ----------
+        height : int
+            The height of the widget in pixels.
+            Setting the height to -1 will expand the widget at 100% height of its
+            container. This is generally a bad idea in a notebook but can be usefull
+            for dashbord applications.
+        """
         if np.isclose(self._height, height):
             return
         self._wcs = {}


### PR DESCRIPTION
## Observed issue
When Aladin is initialized with `height=-1` to take 100% of the enclosed `<div>`, the result is a `1px` vertical height; this is due to the container not being styled correctly. It seems like that the resizing is based on the viewport of the not yet `visible/displayed <div>` container and as such its vertical height is calculated as `0`.
## Example (before)
<img width="788" alt="ipyaladin before" src="https://github.com/user-attachments/assets/5396f88f-dec8-4d7d-869e-ea1945ee1df7" />

## Example (after)
<img width="874" alt="ipyaladin after" src="https://github.com/user-attachments/assets/31797e54-57ef-4b82-9ff8-a60db4a54f7a" />
