### PR TITLE
add: changing viewer rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- `rotation` parameter can now be called to rotate the ipyaladin viewer [#146]
+
 ## [0.6.0]
 
 ## Added

--- a/examples/02_Base_Commands.ipynb
+++ b/examples/02_Base_Commands.ipynb
@@ -96,8 +96,10 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "aladin.rotation = 180"
    ]

--- a/examples/02_Base_Commands.ipynb
+++ b/examples/02_Base_Commands.ipynb
@@ -92,6 +92,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The orientation of the view (view center to north pole angle in degrees) can be set"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "aladin.rotation = 180"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin.rotation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The overlay survey is always on top of the base layer"
    ]
   },
@@ -134,7 +157,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The target and field of view can be set with astropy objects"
+    "The target, rotation, and field of view can be set with astropy objects"
    ]
   },
   {
@@ -144,6 +167,15 @@
    "outputs": [],
    "source": [
     "aladin.target = SkyCoord(\"12h00m00s\", \"-30d00m00s\", frame=\"icrs\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin.rotation = Angle(0, \"deg\")"
    ]
   },
   {

--- a/examples/11_Extracting_information_from_the_view.ipynb
+++ b/examples/11_Extracting_information_from_the_view.ipynb
@@ -81,7 +81,8 @@
     "aladin.survey = \"CDS/P/PLANCK/R2/HFI/color\"\n",
     "aladin.target = \"LMC\"\n",
     "aladin.frame = \"Galactic\"\n",
-    "aladin.fov = 50"
+    "aladin.fov = 50\n",
+    "aladin.rotation = 90"
    ]
   },
   {
@@ -122,6 +123,26 @@
    "outputs": [],
    "source": [
     "aladin.fov_xy  # Recover the current field of view for the x and y axis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fcd830c2",
+   "metadata": {},
+   "source": [
+    "## Getting the rotation\n",
+    "\n",
+    "The rotation of the view (view center to north pole angle in degrees) can be found with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c20e7c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin.rotation  # Recover the current rotation of the view"
    ]
   },
   {

--- a/js/models/event_handler.js
+++ b/js/models/event_handler.js
@@ -47,6 +47,15 @@ export default class EventHandler {
   }
 
   /**
+   * Updates the view center rotation in the model.
+   * WARNING: This method don't call model.save_changes()!
+   */
+  updateRotation() {
+    if (!this.isLastDiv()) return;
+    this.model.set("_rotation", this.aladin.getRotation());
+  }
+
+  /**
    * Updates the 2-axis FoV in the model.
    * WARNING: This method don't call model.save_changes()!
    */
@@ -132,6 +141,15 @@ export default class EventHandler {
     /* Div control */
     this.model.on("change:_height", () => {
       setDivHeight(this.model.get("_height"), this.aladinDiv);
+      // Update WCS and FoV only if this is the last div
+      this.updateWCS();
+      this.update2AxisFoV();
+      this.model.save_changes();
+    });
+
+    /* Rotation control */
+    this.model.on("change:_rotation", () => {
+      setRotation(this.model.get("_rotation"), this.aladinDiv);
       // Update WCS and FoV only if this is the last div
       this.updateWCS();
       this.update2AxisFoV();
@@ -273,6 +291,7 @@ export default class EventHandler {
     this.eventHandlers = {
       add_marker: this.messageHandler.handleAddMarker,
       change_fov: this.messageHandler.handleChangeFoV,
+      change_rotation: this.messageHandler.handleChangeRotation,
       goto_ra_dec: this.messageHandler.handleGotoRaDec,
       save_view_as_image: this.messageHandler.handleSaveViewAsImage,
       add_fits: this.messageHandler.handleAddFits,
@@ -302,6 +321,7 @@ export default class EventHandler {
     this.model.off("change:_target");
     this.model.off("change:_fov");
     this.model.off("change:_height");
+    this.model.off("change:_rotation");
     this.model.off("change:coo_frame");
     this.model.off("change:survey");
     this.model.off("change:overlay_survey");

--- a/js/models/event_handler.js
+++ b/js/models/event_handler.js
@@ -202,6 +202,17 @@ export default class EventHandler {
       }
     });
 
+    this.aladin.on("rotationChanged", (object) => {
+      if (object["data"] !== undefined) {
+        this.model.send({
+          event_type: "rotation_changed",
+          content: {
+            rotation: object["rotation"],
+          },
+        });
+      }
+    });
+
     this.aladin.on("objectClicked", (clicked) => {
       if (clicked) {
         let clickedContent = {

--- a/js/models/event_handler.js
+++ b/js/models/event_handler.js
@@ -48,7 +48,7 @@ export default class EventHandler {
 
   /**
    * Updates the view center rotation in the model.
-   * WARNING: This method don't call model.save_changes()!
+   * WARNING: This method doesn't call model.save_changes()!
    */
   updateRotation() {
     if (!this.isLastDiv()) return;

--- a/js/models/event_handler.js
+++ b/js/models/event_handler.js
@@ -51,8 +51,8 @@ export default class EventHandler {
    * WARNING: This method doesn't call model.save_changes()!
    */
   updateRotation() {
-    if (!this.isLastDiv()) return;
-    this.model.set("_rotation", this.aladin.getRotation());
+    let rotation = this.model.get("_rotation");
+    this.aladin.setRotation(rotation);
   }
 
   /**
@@ -144,6 +144,7 @@ export default class EventHandler {
       // Update WCS and FoV only if this is the last div
       this.updateWCS();
       this.update2AxisFoV();
+      if (!this.isLastDiv()) return;
       this.model.save_changes();
     });
 
@@ -203,14 +204,9 @@ export default class EventHandler {
     });
 
     this.aladin.on("rotationChanged", (object) => {
-      if (object["data"] !== undefined) {
-        this.model.send({
-          event_type: "rotation_changed",
-          content: {
-            rotation: object["rotation"],
-          },
-        });
-      }
+      this.updateRotation();
+      if (!this.isLastDiv()) return;
+      this.model.save_changes();
     });
 
     this.aladin.on("objectClicked", (clicked) => {
@@ -302,7 +298,6 @@ export default class EventHandler {
     this.eventHandlers = {
       add_marker: this.messageHandler.handleAddMarker,
       change_fov: this.messageHandler.handleChangeFoV,
-      change_rotation: this.messageHandler.handleChangeRotation,
       goto_ra_dec: this.messageHandler.handleGotoRaDec,
       save_view_as_image: this.messageHandler.handleSaveViewAsImage,
       add_fits: this.messageHandler.handleAddFits,

--- a/js/models/event_handler.js
+++ b/js/models/event_handler.js
@@ -149,7 +149,7 @@ export default class EventHandler {
 
     /* Rotation control */
     this.model.on("change:_rotation", () => {
-      setRotation(this.model.get("_rotation"), this.aladinDiv);
+      this.updateRotation(this.model.get("_rotation"), this.aladinDiv);
       // Update WCS and FoV only if this is the last div
       this.updateWCS();
       this.update2AxisFoV();

--- a/js/models/message_handler.js
+++ b/js/models/message_handler.js
@@ -38,10 +38,6 @@ export default class MessageHandler {
     this.aladin.gotoRaDec(msg["ra"], msg["dec"]);
   }
 
-  handleChangeRotation(msg) {
-    this.aladin.setRotation(msg["rotation"]);
-  }
-
   async handleSaveViewAsImage(msg) {
     const path = msg["path"];
     const format = msg["format"];

--- a/js/models/message_handler.js
+++ b/js/models/message_handler.js
@@ -38,6 +38,10 @@ export default class MessageHandler {
     this.aladin.gotoRaDec(msg["ra"], msg["dec"]);
   }
 
+  handleChangeRotation(msg) {
+    this.aladin.setRotation(msg["rotation"]);
+  }
+
   async handleSaveViewAsImage(msg) {
     const path = msg["path"];
     const format = msg["format"];

--- a/js/widget.js
+++ b/js/widget.js
@@ -39,7 +39,7 @@ function initAladinLite(model, el) {
   });
   const wcs = { ...aladin.getViewWCS() };
   model.set("_wcs", wcs);
-  const rotation = aladin.getRotation();
+  const rotation = { ...aladin.getRotation() };
   model.set("_rotation", rotation);
 
   model.set("_is_loaded", true);

--- a/js/widget.js
+++ b/js/widget.js
@@ -31,7 +31,7 @@ function initAladinLite(model, el) {
   const raDec = model.get("_target").split(" ");
   aladin.gotoRaDec(raDec[0], raDec[1]);
 
-  // Set current FoV and WCS
+  // Set current FoV, WCS, and rotation
   const twoAxisFoV = { ...aladin.getFov() };
   model.set("_fov_xy", {
     x: twoAxisFoV[0],
@@ -39,6 +39,8 @@ function initAladinLite(model, el) {
   });
   const wcs = { ...aladin.getViewWCS() };
   model.set("_wcs", wcs);
+  const rotation = { ...aladin.getRotation() };
+  model.set("_rotation", rotation);
   model.set("_is_loaded", true);
   model.save_changes();
 

--- a/js/widget.js
+++ b/js/widget.js
@@ -39,7 +39,7 @@ function initAladinLite(model, el) {
   });
   const wcs = { ...aladin.getViewWCS() };
   model.set("_wcs", wcs);
-  const rotation = { ...aladin.getRotation() };
+  const rotation = aladin.getRotation();
   model.set("_rotation", rotation);
 
   model.set("_is_loaded", true);

--- a/js/widget.js
+++ b/js/widget.js
@@ -39,8 +39,9 @@ function initAladinLite(model, el) {
   });
   const wcs = { ...aladin.getViewWCS() };
   model.set("_wcs", wcs);
-  const rotation = { ...aladin.getRotation() };
+  const rotation = aladin.getRotation();
   model.set("_rotation", rotation);
+
   model.set("_is_loaded", true);
   model.save_changes();
 

--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -293,6 +293,7 @@ class Aladin(anywidget.AnyWidget):
 
     @height.setter
     def height(self, height: int) -> None:
+        """Height can be set with integer representing number of pixels."""
         if np.isclose(self._height, height):
             return
         self._wcs = {}
@@ -308,9 +309,6 @@ class Aladin(anywidget.AnyWidget):
         Positive angles rotates the view in the counter clockwise
         order (or towards the east).
 
-        It can be set with either a float number in degrees
-        or an astropy.coordinates.Angle object.
-
         Returns
         -------
         astropy.coordinates.Angle
@@ -322,6 +320,12 @@ class Aladin(anywidget.AnyWidget):
 
     @rotation.setter
     def rotation(self, rotation: Union[float, Angle]) -> None:
+        """
+        Rotation can be set with view center to north pole angle in degrees.
+
+        Rotation can either a float number in degrees
+        or an `~astropy.coordinates.Angle` object.
+        """
         if isinstance(rotation, Angle):
             rotation = rotation.deg
         if np.isclose(self._rotation, rotation):
@@ -383,9 +387,6 @@ class Aladin(anywidget.AnyWidget):
     def fov(self) -> Angle:
         """The field of view of the Aladin Lite widget along the horizontal axis.
 
-        It can be set with either a float number in degrees
-        or an astropy.coordinates.Angle object.
-
         Returns
         -------
         astropy.coordinates.Angle
@@ -400,6 +401,12 @@ class Aladin(anywidget.AnyWidget):
 
     @fov.setter
     def fov(self, fov: Union[float, Angle]) -> None:
+        """
+        FoV can be set with angle representing horizontal axis.
+
+        FoV can be set with either a float number in degrees
+        or an `~astropy.coordinates.Angle` object.
+        """
         if isinstance(fov, Angle):
             fov = fov.deg
         if np.isclose(fov, self._fov):
@@ -412,10 +419,6 @@ class Aladin(anywidget.AnyWidget):
     @property
     def target(self) -> Union[SkyCoord, Tuple[float, float]]:
         """The target of the Aladin Lite widget.
-
-        The target can be provided as coordinates (either
-        `~astropy.coordinates.SkyCoord` or (`~astropy.coordinates.Longitude`,
-        `~astropy.coordinates.Latitude`)) or as a name (as a string).
 
         The conversion from a name to coordinates does call different online services
         depending on the base layer of the widget:
@@ -451,6 +454,13 @@ class Aladin(anywidget.AnyWidget):
 
     @target.setter
     def target(self, target: Union[str, SkyCoord, Tuple[float, float]]) -> None:
+        """
+        Target can be set using coordinates or name.
+
+        Target can be provided as coordinates (either
+        `~astropy.coordinates.SkyCoord` or (`~astropy.coordinates.Longitude`,
+        `~astropy.coordinates.Latitude`)) or as a name (as a string).
+        """
         if isinstance(target, Tuple):
             lon, lat = target[0].deg, target[1].deg
         elif isinstance(target, str):  # If the target is a string, parse it

--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -326,10 +326,7 @@ class Aladin(anywidget.AnyWidget):
             rotation = rotation.deg
         if np.isclose(self._rotation, rotation):
             return
-        self._wcs = {}
-        self._fov_xy = {}
         self._rotation = rotation
-        self.send({"event_name": "change_rotation", "rotation": rotation})
 
     @property
     def wcs(self) -> WCS:
@@ -586,7 +583,7 @@ class Aladin(anywidget.AnyWidget):
 
         """
         try:
-            from astroquery.hips2fits import hips2fits
+            from astroquery.hips2fits import hips2fits  # noqa: PLC0415
         except ImportError as imp:
             raise ValueError(
                 "To use 'get_view_as_fits', you need astroquery. "
@@ -707,7 +704,7 @@ class Aladin(anywidget.AnyWidget):
             )
         else:
             try:
-                from mocpy import MOC
+                from mocpy import MOC  # noqa: PLC0415
 
                 if isinstance(moc, MOC):
                     self.send(
@@ -914,7 +911,7 @@ class Aladin(anywidget.AnyWidget):
                     "See the documentation for the supported region types."
                 )
 
-            from .utils._region_converter import RegionInfos
+            from .utils._region_converter import RegionInfos  # noqa: PLC0415
 
             # Define behavior for each region type
             regions_infos.append(RegionInfos(region_element).to_clean_dict())

--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -221,6 +221,10 @@ class Aladin(anywidget.AnyWidget):
         # https://github.com/jupyter-widgets/ipywidgets/blob/main/python/ipywidgets/ipywidgets/widgets/domwidget.py
         for key in ["layout", "tabbable", "tooltip"]:
             init_options.pop(key, None)
+        if "north_pole_orientation" not in init_options:
+            init_options["north_pole_orientation"] = init_options.get("rotation", 0)
+        else:
+            init_options["rotation"] = init_options["north_pole_orientation"]
         # some init options are properties here
         self.height = init_options.get("height", self._height)
         self.rotation = init_options.get("rotation", self._rotation)

--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -143,6 +143,7 @@ class Aladin(anywidget.AnyWidget):
     # Options for the view initialization
     _init_options = traitlets.Dict().tag(sync=True)
     _height = Int(400).tag(sync=True, init_option=True)
+    _rotation = Float(0).tag(sync=True, init_option=True)
     _target = Unicode(
         "0 0",
         help="A private trait that stores the current target of the widget in a string."
@@ -222,6 +223,7 @@ class Aladin(anywidget.AnyWidget):
             init_options.pop(key, None)
         # some init options are properties here
         self.height = init_options.get("height", self._height)
+        self.rotation = init_options.get("rotation", self._rotation)
         self.target = init_options.get("target", self._target)
         self.fov = init_options.get("fov", self._fov)
         # apply different default options from Aladin-Lite
@@ -293,6 +295,32 @@ class Aladin(anywidget.AnyWidget):
         self._wcs = {}
         self._fov_xy = {}
         self._height = height
+
+    @property
+    def rotation(self) -> float:
+        """The center rotation of the widget.
+
+        This is the view center to north pole angle in degrees.
+        This is equivalent to getting the 3rd Euler angle.
+        Positive angles rotates the view in the counter clockwise
+        order (or towards the east).
+
+        Returns
+        -------
+        float
+            The center rotation of the widget in degrees.
+            The default rotation is 0 degrees.
+        """
+        return self._rotation
+
+    @rotation.setter
+    def rotation(self, rotation: float) -> None:
+        if np.isclose(self._rotation, rotation):
+            return
+        self._wcs = {}
+        self._fov_xy = {}
+        self._rotation = rotation
+        self.send({"event_name": "change_rotation", "rotation": rotation})
 
     @property
     def wcs(self) -> WCS:

--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -293,7 +293,6 @@ class Aladin(anywidget.AnyWidget):
 
     @height.setter
     def height(self, height: int) -> None:
-        """Height can be set with integer representing number of pixels."""
         if np.isclose(self._height, height):
             return
         self._wcs = {}
@@ -309,6 +308,9 @@ class Aladin(anywidget.AnyWidget):
         Positive angles rotates the view in the counter clockwise
         order (or towards the east).
 
+        It can be set with either a float number in degrees
+        or an astropy.coordinates.Angle object.
+
         Returns
         -------
         astropy.coordinates.Angle
@@ -320,12 +322,6 @@ class Aladin(anywidget.AnyWidget):
 
     @rotation.setter
     def rotation(self, rotation: Union[float, Angle]) -> None:
-        """
-        Rotation can be set with view center to north pole angle in degrees.
-
-        Rotation can either a float number in degrees
-        or an `~astropy.coordinates.Angle` object.
-        """
         if isinstance(rotation, Angle):
             rotation = rotation.deg
         if np.isclose(self._rotation, rotation):
@@ -387,6 +383,9 @@ class Aladin(anywidget.AnyWidget):
     def fov(self) -> Angle:
         """The field of view of the Aladin Lite widget along the horizontal axis.
 
+        It can be set with either a float number in degrees
+        or an astropy.coordinates.Angle object.
+
         Returns
         -------
         astropy.coordinates.Angle
@@ -401,12 +400,6 @@ class Aladin(anywidget.AnyWidget):
 
     @fov.setter
     def fov(self, fov: Union[float, Angle]) -> None:
-        """
-        FoV can be set with angle representing horizontal axis.
-
-        FoV can be set with either a float number in degrees
-        or an `~astropy.coordinates.Angle` object.
-        """
         if isinstance(fov, Angle):
             fov = fov.deg
         if np.isclose(fov, self._fov):
@@ -419,6 +412,10 @@ class Aladin(anywidget.AnyWidget):
     @property
     def target(self) -> Union[SkyCoord, Tuple[float, float]]:
         """The target of the Aladin Lite widget.
+
+        The target can be provided as coordinates (either
+        `~astropy.coordinates.SkyCoord` or (`~astropy.coordinates.Longitude`,
+        `~astropy.coordinates.Latitude`)) or as a name (as a string).
 
         The conversion from a name to coordinates does call different online services
         depending on the base layer of the widget:
@@ -454,13 +451,6 @@ class Aladin(anywidget.AnyWidget):
 
     @target.setter
     def target(self, target: Union[str, SkyCoord, Tuple[float, float]]) -> None:
-        """
-        Target can be set using coordinates or name.
-
-        Target can be provided as coordinates (either
-        `~astropy.coordinates.SkyCoord` or (`~astropy.coordinates.Longitude`,
-        `~astropy.coordinates.Latitude`)) or as a name (as a string).
-        """
         if isinstance(target, Tuple):
             lon, lat = target[0].deg, target[1].deg
         elif isinstance(target, str):  # If the target is a string, parse it

--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -221,13 +221,12 @@ class Aladin(anywidget.AnyWidget):
         # https://github.com/jupyter-widgets/ipywidgets/blob/main/python/ipywidgets/ipywidgets/widgets/domwidget.py
         for key in ["layout", "tabbable", "tooltip"]:
             init_options.pop(key, None)
-        if "north_pole_orientation" not in init_options:
-            init_options["north_pole_orientation"] = init_options.get("rotation", 0)
-        else:
-            init_options["rotation"] = init_options["north_pole_orientation"]
+        init_options["north_pole_orientation"] = init_options.get(
+            "north_pole_orientation", init_options.get("rotation", 0)
+        )
         # some init options are properties here
         self.height = init_options.get("height", self._height)
-        self.rotation = init_options.get("rotation", self._rotation)
+        self.rotation = init_options.get("north_pole_orientation", self._rotation)
         self.target = init_options.get("target", self._target)
         self.fov = init_options.get("fov", self._fov)
         # apply different default options from Aladin-Lite

--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -309,16 +309,22 @@ class Aladin(anywidget.AnyWidget):
         Positive angles rotates the view in the counter clockwise
         order (or towards the east).
 
+        It can be set with either a float number in degrees
+        or an astropy.coordinates.Angle object.
+
         Returns
         -------
-        float
-            The center rotation of the widget in degrees.
-            The default rotation is 0 degrees.
+        astropy.coordinates.Angle
+            An astropy.coordinates.Angle object representing the center
+            rotation of the widget in degrees. The default rotation is
+            0 degrees.
         """
-        return self._rotation
+        return Angle(self._rotation, unit="deg")
 
     @rotation.setter
-    def rotation(self, rotation: float) -> None:
+    def rotation(self, rotation: Union[float, Angle]) -> None:
+        if isinstance(rotation, Angle):
+            rotation = rotation.deg
         if np.isclose(self._rotation, rotation):
             return
         self._wcs = {}

--- a/src/tests/test_aladin.py
+++ b/src/tests/test_aladin.py
@@ -152,7 +152,7 @@ def test_aladin_float_rotation_set(angle: float) -> None:
     assert aladin.rotation.deg == angle
 
 
-@pytest.mark.parametrize("angle", test_aladin_float_fov)
+@pytest.mark.parametrize("angle", test_aladin_float_rotation)
 def test_aladin_angle_rotation_set(angle: float) -> None:
     """Test setting the rotation of an Aladin object with an Angle object.
 
@@ -165,6 +165,51 @@ def test_aladin_angle_rotation_set(angle: float) -> None:
     angle_rotation = Angle(angle, unit="deg")
     aladin.rotation = angle_rotation
     assert aladin.rotation.deg == angle_rotation.deg
+
+
+@pytest.mark.parametrize("angle", test_aladin_float_rotation)
+def test_aladin_init_rotation(angle: float) -> None:
+    """Test initializing an Aladin object with rotation set.
+
+    Parameters
+    ----------
+    angle : float
+        The angle to set.
+
+    """
+    test_aladin = Aladin(rotation=angle)
+    assert test_aladin.rotation.deg == angle
+
+
+@pytest.mark.parametrize("angle", test_aladin_float_rotation)
+def test_aladin_init_north_pole_orientation(angle: float) -> None:
+    """Test initializing Aladin object with north_pole_orientation set.
+
+    Parameters
+    ----------
+    angle : float
+        The angle to set.
+
+    """
+    test_aladin = Aladin(north_pole_orientation=angle)
+    assert test_aladin.rotation.deg == angle
+
+
+@pytest.mark.parametrize("angle", test_aladin_float_rotation)
+def test_aladin_init_north_pole_orientation_overrides_rotation(angle: float) -> None:
+    """
+    Test init Aladin object with north_pole_orientation and rotation set.
+
+    north_pole_orientation should override rotation.
+
+    Parameters
+    ----------
+    angle : float
+        The angle to set.
+
+    """
+    test_aladin = Aladin(north_pole_orientation=angle, rotation=180)
+    assert test_aladin.rotation.deg == angle
 
 
 test_stcs_iterables = [

--- a/src/tests/test_aladin.py
+++ b/src/tests/test_aladin.py
@@ -129,6 +129,44 @@ def test_aladin_angle_fov_set(angle: float) -> None:
     assert aladin.fov.deg == angle_fov.deg
 
 
+test_aladin_float_rotation = [
+    0,
+    360,
+    180,
+    -180,
+    720,
+]
+
+
+@pytest.mark.parametrize("angle", test_aladin_float_rotation)
+def test_aladin_float_rotation_set(angle: float) -> None:
+    """Test setting the rotation of an Aladin object with a float.
+
+    Parameters
+    ----------
+    angle : float
+        The angle to set.
+
+    """
+    aladin.rotation = angle
+    assert aladin.rotation.deg == angle
+
+
+@pytest.mark.parametrize("angle", test_aladin_float_fov)
+def test_aladin_angle_rotation_set(angle: float) -> None:
+    """Test setting the rotation of an Aladin object with an Angle object.
+
+    Parameters
+    ----------
+    angle : float
+        The angle to set.
+
+    """
+    angle_rotation = Angle(angle, unit="deg")
+    aladin.rotation = angle_rotation
+    assert aladin.rotation.deg == angle_rotation.deg
+
+
 test_stcs_iterables = [
     "CIRCLE ICRS 258.93205686 43.13632863 0.625",
     [


### PR DESCRIPTION
### Overview
Proposed changes to allow for varying the orientation of the viewer.

aladin-lite supports functionality for its mobile device users to rotate the viewer using touchscreen interaction. This PR allows for ipyaladin users to get and set the rotation of the viewer, which is defined by aladin-lite as the view center to north pole angle in degrees. Exposing this functionality will be helpful for future development to allow for viewer-syncing work. Below are screenshots illustrating how to leverage this functionality.

The default is to set the `rotation` == 0, and rotation accepts a float number in degrees or an astropy.coordinates.Angle object. I included testing for both floats and degrees, and I updated a few of the example notebooks to demonstrate functionality.

### Default initialization (`rotation`=0)
<img width="1025" alt="Screenshot 2025-06-27 at 12 27 31 PM" src="https://github.com/user-attachments/assets/90561cbd-c740-42f9-89ea-ac9d20afdee1" />

### Setting `rotation` = 180
<img width="1025" alt="Screenshot 2025-06-27 at 12 28 28 PM" src="https://github.com/user-attachments/assets/e1b32075-947f-47d3-887c-db27644a4862" />
