### PR TITLE
bug: fixing overlay name option for stcs string graphic overlays

### DIFF
--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -549,7 +549,7 @@ class Aladin(anywidget.AnyWidget):
 
         """
         try:
-            from astroquery.hips2fits import hips2fits
+            from astroquery.hips2fits import hips2fits  # noqa: PLC0415
         except ImportError as imp:
             raise ValueError(
                 "To use 'get_view_as_fits', you need astroquery. "
@@ -670,7 +670,7 @@ class Aladin(anywidget.AnyWidget):
             )
         else:
             try:
-                from mocpy import MOC
+                from mocpy import MOC  # noqa: PLC0415
 
                 if isinstance(moc, MOC):
                     self.send(
@@ -877,7 +877,7 @@ class Aladin(anywidget.AnyWidget):
                     "See the documentation for the supported region types."
                 )
 
-            from .utils._region_converter import RegionInfos
+            from .utils._region_converter import RegionInfos  # noqa: PLC0415
 
             # Define behavior for each region type
             regions_infos.append(RegionInfos(region_element).to_clean_dict())
@@ -951,7 +951,7 @@ class Aladin(anywidget.AnyWidget):
             {
                 "event_name": "add_overlay",
                 "regions_infos": regions_infos,
-                "graphic_options": {},
+                "graphic_options": overlay_options,
             }
         )
 


### PR DESCRIPTION
Currently, any name passed to `add_graphic_overlay_from_stcs` as a part of `**overlay_options` isn't passed along for handling in aladin-lite. This fix allows for any user-specified names to populate forward. Shown below is a quick comparison of running without this change (top) vs with this change (bottom) when a user passes the argument `name = "testing"`
<img width="515" height="406" alt="Screenshot 2025-08-19 at 12 17 30 PM" src="https://github.com/user-attachments/assets/32f0fb49-2343-441e-91ec-672e5244f3c6" />
<img width="515" height="406" alt="Screenshot 2025-08-19 at 12 06 33 PM" src="https://github.com/user-attachments/assets/e6973482-c000-439c-bfbc-c8ae83a0bee5" />

Also included in the PR are noqa 