### PR TITLE
Delay API calls when the widget is not loaded 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `rotation` parameter can now be called to rotate the ipyaladin viewer [#146]
 
+## Fixed
+
+- observe `_is_loaded` trait to call the Aladin API when the javascript is loaded [#149]
+
 ## [0.6.0]
 
 ## Added

--- a/examples/09_Displaying_Shapes.ipynb
+++ b/examples/09_Displaying_Shapes.ipynb
@@ -54,15 +54,6 @@
    "outputs": [],
    "source": [
     "aladin = Aladin(target=\"M 51\", fov=1.2)\n",
-    "aladin"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "aladin.add_graphic_overlay_from_stcs(\n",
     "    \"\"\"Polygon ICRS 202.63748 47.24951 202.46382 47.32391 202.46379 47.32391 202.45459\n",
     "    47.32391 202.34527 47.20597 202.34527 47.20596 202.34529 47.19710 202.51870\n",
@@ -77,7 +68,9 @@
     ")\n",
     "aladin.add_graphic_overlay_from_stcs(\n",
     "    \"Circle ICRS 202.4656816 +47.1999842 0.04\", color=\"#4488ee\"\n",
-    ")"
+    ")\n",
+    "\n",
+    "aladin"
    ]
   },
   {
@@ -191,45 +184,16 @@
    "source": [
     "aladin.add_graphic_overlay_from_region([circle, ellipse, line, polygon, rectangle])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "base",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.8"
-  },
-  "toc": {
-   "base_numbering": 1,
-   "nav_menu": {},
-   "number_sections": false,
-   "sideBar": false,
-   "skip_h1_title": false,
-   "title_cell": "Table of Contents",
-   "title_sidebar": "Contents",
-   "toc_cell": false,
-   "toc_position": {},
-   "toc_section_display": false,
-   "toc_window_display": false
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "85bb43f988bdbdc027a50b6d744a62eda8a76617af1f4f9b115d38242716dbac"
-   }
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 4
 }

--- a/src/ipyaladin/utils/call_store.py
+++ b/src/ipyaladin/utils/call_store.py
@@ -1,0 +1,24 @@
+from traitlets import (
+    Any,
+)
+
+
+class CallStore:
+    """A simple call store.
+
+    This is used to store user calls to Aladin API in case the widget is not properly
+    loaded on the JS side. Whenever it gets loaded, then the calls are run in the
+    inserting order.
+    """
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    def add(self, func: Any, *args: Any, **kwargs: Any) -> None:
+        """Add a call to the store."""
+        self.calls.append((func, args, kwargs))
+
+    def run_all(self) -> None:
+        """Run all the stored calls in the right order."""
+        for func, args, kwargs in self.calls:
+            func(*args, **kwargs)

--- a/src/tests/test_aladin.py
+++ b/src/tests/test_aladin.py
@@ -15,6 +15,11 @@ from .test_coordinate_parser import test_is_coordinate_string_values
 
 aladin = Aladin()
 
+# Tell python that the JS part is loaded
+# so that adding overlay requests are sent
+# through the events/traitlets system.
+aladin._is_loaded = True
+
 
 # monkeypatched sesame call to avoid remote access during tests
 @pytest.fixture


### PR DESCRIPTION
This aims to target the issue:  https://github.com/cds-astro/ipyaladin/issues/128

Many Aladin API calls (for example when it comes to add overlays like a table, a moc or a region to an Aladin object) are not taken into account if the widget is not displayed (i.e. aladin lite JS code is not loaded).

This PR is inspired by the work done for mast_aladin_lite by @bmorris3 in https://github.com/spacetelescope/mast-aladin-lite/pull/44

## Description

* When a API call is done before the widget is loaded I store the call (function call + args + kwargs) in a list of calls.
* `_is_loaded` traitlet is observed for a change on the python side.
* When the widget is loaded I run all the stored API calls in the right order.

With that, one should be able to run many aladin API calls without the necessity to display the aladin object (it also works when the API calls are done on several cells before the cell where the user decides to display the view i.e. the user does not need to put all in just one cell).

<img width="1205" height="670" alt="Capture d’écran 2025-08-20 à 15 56 09" src="https://github.com/user-attachments/assets/c5d884e1-2acc-4317-9164-313147ef9cd8" />


Some tests are not passing because in case we store the calls for later, it is not executed at the time of the call (but rather when the widget is loaded) which makes the send mocking tests failing. Not sure how to deal with them.