### PR TITLE
Sync overlays through traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `projection` parameter can now be called to change the projection of the
   ipyaladin viewer [#172]
 
+## Fixed
+
+- Overlays are displayed on the generated HTML static file because it is passed with
+  traitlets instead of being sent with events. This fixes documentation examples [#151].
+
 ## [0.7.0]
 
 ## Added

--- a/examples/12_Planetary_surveys.ipynb
+++ b/examples/12_Planetary_surveys.ipynb
@@ -49,7 +49,7 @@
    "id": "35ea9256",
    "metadata": {},
    "source": [
-    "The target does not return a `SkyCoord` object anymore, since we don't represent the sky here. It is a couple of `Longitude` and `Latitude`."
+    "The target does not return a `SkyCoord` object anymore, since we don't represent the sky here. It is a tuple of `Longitude` and `Latitude`."
    ]
   },
   {

--- a/js/models/event_handler.js
+++ b/js/models/event_handler.js
@@ -289,9 +289,11 @@ export default class EventHandler {
       },
       /* Rotation control */
       _rotation: (rotation) => {
+        if (rotation === this.aladin.getRotation()) {
+          return;
+        }
         // And propagate it to Aladin Lite
         this.aladin.setRotation(rotation);
-
         // Update WCS and FoV only if this is the last div
         this.updateWCS();
         this.update2AxisFoV();

--- a/js/models/event_handler.js
+++ b/js/models/event_handler.js
@@ -1,5 +1,11 @@
 import MessageHandler from "./message_handler";
-import { divNumber, setDivNumber, Lock, setDivHeight } from "../utils";
+import {
+  divNumber,
+  setDivNumber,
+  Lock,
+  setDivHeight,
+  isLiveSession,
+} from "../utils";
 
 export default class EventHandler {
   /**
@@ -245,6 +251,9 @@ export default class EventHandler {
       this.model.save_changes();
     });
 
+    // Detect environment
+    const isLive = isLiveSession(this.model);
+
     /* ----------------------- */
     /* Traits listeners        */
     /* ----------------------- */
@@ -323,7 +332,64 @@ export default class EventHandler {
           overlay.setAlpha(opacity);
         }
       },
+      colormap: (colormap) => {
+        this.aladin.getBaseImageLayer().setColormap(colormap);
+      },
+      projection: (projection) => {
+        this.aladin.setProjection(projection);
+
+        this.updateWCS();
+        this.update2AxisFoV();
+        this.model.save_changes();
+      },
     };
+
+    // Overlays traitlet listening
+    const handleOverlay = (overlay) => {
+      if (overlay.action === "add") {
+        switch (overlay.type) {
+          case "table":
+            // A table is transcripted to an ArrayBuffer (thanks to widget_serialization)
+            this.messageHandler.handleAddTable(overlay);
+            break;
+          case "catalog_from_url":
+            this.messageHandler.handleAddCatalogFromURL(overlay);
+            break;
+          case "MOC_from_url":
+            this.messageHandler.handleAddMOCFromURL(overlay);
+            break;
+          case "MOC_from_dict":
+            this.messageHandler.handleAddMOCFromDict(overlay);
+            break;
+          case "regions_stcs":
+            this.messageHandler.handleAddGraphicOverlay(overlay);
+            break;
+          case "regions":
+            this.messageHandler.handleAddGraphicOverlay(overlay);
+            break;
+          case "fits-image":
+            this.messageHandler.handleAddFitsImage(overlay);
+            break;
+          default:
+            break;
+        }
+      } else {
+        // TODO: remove overlay
+      }
+    };
+
+    if (isLive) {
+      // Default behavior: do not listen for overlays but _overlay_patch when ipyaladin
+      // is connected to a jupyter/jupyterlab session (i.e. not exported to HTML)
+      this.traitHandlers["_overlay_patch"] = handleOverlay;
+    } else {
+      // static HTML file export (i.e. example HTML documentation files or HTML export of a notebook)
+      this.traitHandlers["overlays"] = (overlays) => {
+        for (const overlay of overlays) {
+          handleOverlay(overlay);
+        }
+      };
+    }
 
     for (var trait in this.traitHandlers) {
       let handler = this.traitHandlers[trait];
@@ -335,15 +401,15 @@ export default class EventHandler {
     this.eventHandlers = {
       add_marker: this.messageHandler.handleAddMarker,
       save_view_as_image: this.messageHandler.handleSaveViewAsImage,
-      add_fits: this.messageHandler.handleAddFits,
-      add_catalog_from_URL: this.messageHandler.handleAddCatalogFromURL,
-      add_MOC_from_URL: this.messageHandler.handleAddMOCFromURL,
-      add_MOC_from_dict: this.messageHandler.handleAddMOCFromDict,
-      add_overlay: this.messageHandler.handleAddOverlay,
-      change_colormap: this.messageHandler.handleChangeColormap,
       get_JPG_thumbnail: this.messageHandler.handleGetJPGThumbnail,
       trigger_selection: this.messageHandler.handleTriggerSelection,
-      add_table: this.messageHandler.handleAddTable,
+      //add_fits: this.messageHandler.handleAddFits,
+      //add_catalog_from_URL: this.messageHandler.handleAddCatalogFromURL,
+      //add_MOC_from_URL: this.messageHandler.handleAddMOCFromURL,
+      //add_MOC_from_dict: this.messageHandler.handleAddMOCFromDict,
+      //add_overlay: this.messageHandler.handleAddGraphicOverlay,
+      //add_table: this.messageHandler.handleAddTable,
+      //change_colormap: this.messageHandler.handleChangeColormap,
     };
 
     this.model.on("msg:custom", (msg, buffers) => {

--- a/js/models/message_handler.js
+++ b/js/models/message_handler.js
@@ -49,11 +49,11 @@ export default class MessageHandler {
     );
   }
 
-  handleAddFits(msg, buffers) {
-    const options = convertOptionNamesToCamelCase(msg["options"] || {});
+  handleAddFitsImage(overlay) {
+    const options = convertOptionNamesToCamelCase(overlay["options"] || {});
     if (!options.name)
       options.name = `image_${String(++imageCount).padStart(3, "0")}`;
-    const buffer = buffers[0];
+    const buffer = overlay.data.buffer;
     const blob = new Blob([buffer], { type: "application/octet-stream" });
     const url = URL.createObjectURL(blob);
     const image = this.aladin.createImageFITS(url, options, (ra, dec) => {
@@ -64,25 +64,25 @@ export default class MessageHandler {
     this.aladin.setOverlayImageLayer(image, options.name);
   }
 
-  handleAddCatalogFromURL(msg) {
-    const options = convertOptionNamesToCamelCase(msg["options"] || {});
-    this.aladin.addCatalog(A.catalogFromURL(msg["votable_URL"], options));
+  handleAddCatalogFromURL(catalog) {
+    const options = convertOptionNamesToCamelCase(catalog["options"] || {});
+    this.aladin.addCatalog(A.catalogFromURL(catalog["data"], options));
   }
 
-  handleAddMOCFromURL(msg) {
-    const options = convertOptionNamesToCamelCase(msg["options"] || {});
-    this.aladin.addMOC(A.MOCFromURL(msg["moc_URL"], options));
+  handleAddMOCFromURL(moc) {
+    const options = convertOptionNamesToCamelCase(moc["options"] || {});
+    this.aladin.addMOC(A.MOCFromURL(moc["data"], options));
   }
 
-  handleAddMOCFromDict(msg) {
-    const options = convertOptionNamesToCamelCase(msg["options"] || {});
-    this.aladin.addMOC(A.MOCFromJSON(msg["moc_dict"], options));
+  handleAddMOCFromDict(moc) {
+    const options = convertOptionNamesToCamelCase(moc["options"] || {});
+    this.aladin.addMOC(A.MOCFromJSON(moc["data"], options));
   }
 
-  handleAddOverlay(msg) {
-    const regions = msg["regions_infos"];
+  handleAddGraphicOverlay(graphicOverlay) {
+    const regions = graphicOverlay["data"];
     const graphic_options = convertOptionNamesToCamelCase(
-      msg["graphic_options"] || {},
+      graphicOverlay["options"] || {},
     );
     if (!graphic_options["color"]) graphic_options["color"] = "red";
     const overlay = A.graphicOverlay(graphic_options);
@@ -132,10 +132,6 @@ export default class MessageHandler {
     }
   }
 
-  handleChangeColormap(msg) {
-    this.aladin.getBaseImageLayer().setColormap(msg["colormap"]);
-  }
-
   handleGetJPGThumbnail() {
     this.aladin.exportAsPNG();
   }
@@ -147,15 +143,15 @@ export default class MessageHandler {
     this.aladin.select(selectionType);
   }
 
-  handleAddTable(msg, buffers) {
-    const options = convertOptionNamesToCamelCase(msg["options"] || {});
+  handleAddTable(table) {
+    const options = convertOptionNamesToCamelCase(table["options"] || {});
     const circleOptions = convertOptionNamesToCamelCase(
       options.circleError || {},
     );
     const ellipseOptions = convertOptionNamesToCamelCase(
       options.ellipseError || {},
     );
-    const buffer = buffers[0].buffer;
+    const buffer = table.data.buffer;
     const decoder = new TextDecoder("utf-8");
     const blob = new Blob([decoder.decode(buffer)]);
     const url = URL.createObjectURL(blob);

--- a/js/utils.js
+++ b/js/utils.js
@@ -54,6 +54,22 @@ function setDivHeight(height, div) {
   }
 }
 
+// This is needed to know whether ipyaladin is run
+// from a live session or from a static export (HTML)
+// Depending on that, we will listen to specific overlay traitlets.
+// See the overlays and _overlay_patch traitlets definition for more informations.
+function isLiveSession(model) {
+  // ipywidgets v7/v8: model.comm is a Comm in live sessions, null/undefined in static HTML
+  if (model && model.comm && typeof model.comm.send === "function") return true;
+
+  // Extra heuristics if needed (some frontends expose a kernel on the manager)
+  const mgr = model?.widget_manager;
+  if (mgr?.kernel) return true; // classic jupyter notebook
+  if (mgr?.context?.sessionContext?.session?.kernel) return true; // JupyterLab
+
+  return false; // static export (HTML)
+}
+
 export {
   snakeCaseToCamelCase,
   convertOptionNamesToCamelCase,
@@ -61,4 +77,5 @@ export {
   divNumber,
   setDivNumber,
   setDivHeight,
+  isLiveSession,
 };

--- a/js/widget.js
+++ b/js/widget.js
@@ -63,6 +63,10 @@ function render({ model, el }) {
   const wcs = { ...aladin.getViewWCS() };
   model.set("_wcs", wcs);
 
+  // send colormap to python
+  const cmap = aladin.getBaseImageLayer().getColorCfg().colormap;
+  model.set("colormap", cmap);
+
   // Tell the widget is loaded so that all stored calls waiting can be executed
   model.set("_is_loaded", true);
   model.save_changes();

--- a/src/ipyaladin/utils/_region_converter.py
+++ b/src/ipyaladin/utils/_region_converter.py
@@ -4,6 +4,8 @@ from astropy.coordinates import SkyCoord, CartesianRepresentation, Angle
 from astropy.coordinates.matrix_utilities import rotation_matrix
 from astropy.units import Quantity
 
+import traitlets
+
 try:
     from regions import (
         RectangleSkyRegion,
@@ -89,7 +91,7 @@ def rectangle_to_polygon_region(region: RectangleSkyRegion) -> PolygonSkyRegion:
     )
 
 
-class RegionInfos:
+class RegionInfos(traitlets.TraitType):
     """Extract information from a region.
 
     Attributes
@@ -112,6 +114,27 @@ class RegionInfos:
         }
         self.options = {}
         self.from_region(region)
+
+    # inherited from traitlets.TraitType
+    def validate(self, obj: any, value: dict) -> dict:
+        if not isinstance(value, dict):
+            self.error(obj, value)
+
+        required_keys = {"region_type", "infos", "options"}
+        missing = required_keys - value.keys()
+        if missing:
+            raise traitlets.TraitError(f"Missing keys: {missing}")
+
+        if not isinstance(value["options"], dict):
+            self.error(obj, value)
+
+        if not isinstance(value["region_type"], str):
+            self.error(obj, value)
+
+        if not isinstance(value["infos"], dict):
+            self.error(obj, value)
+
+        return value
 
     def from_region(self, region: Union[str, Region]) -> None:
         """Parse a region to extract its information.

--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -20,6 +20,7 @@ except ImportError:
 import warnings
 
 import anywidget
+import ipywidgets as widgets
 from astropy.coordinates import SkyCoord, Angle, Longitude, Latitude
 from astropy.coordinates.name_resolve import NameResolveError
 from astropy.table.table import QTable, Table
@@ -40,6 +41,7 @@ from .elements.error_shape import (
     _error_radius_conversion_factor,
 )
 from .elements.marker import Marker
+from .utils._region_converter import RegionInfos
 
 try:
     from regions import (
@@ -180,6 +182,9 @@ class Aladin(anywidget.AnyWidget):
         "SIN",
         help="The projection for the view. The keywords follow the FITS standard.",
     ).tag(sync=True, init_option=True)
+    colormap = Unicode(
+        help="The colormap of the main survey",
+    ).tag(sync=True)
     # Values
     _ready = Bool(
         False,
@@ -208,6 +213,74 @@ class Aladin(anywidget.AnyWidget):
         survey.default_value,
         help="A private trait for the base layer of the last view. It is useful "
         "to convert the view to an astropy.HDUList",
+    ).tag(sync=True)
+
+    overlays = traitlets.List(
+        traitlets.Dict(
+            traits={
+                "action": traitlets.Enum(["add", "remove"]).tag(sync=True),
+                "options": traitlets.Dict().tag(sync=True),
+                "data": traitlets.Union(
+                    [
+                        # fits-image, astropy/numpy tables
+                        traitlets.Bytes(),
+                        # URLs of catalogs, MOCs
+                        traitlets.Unicode(),
+                        # JSON MOC
+                        traitlets.Dict(),
+                        # Sky regions (from stcs or astropy.regions objects)
+                        traitlets.List(trait=RegionInfos("")),
+                    ]
+                ).tag(sync=True, **widgets.widget_serialization),
+                "type": traitlets.Enum(
+                    [
+                        "table",
+                        "catalog_from_url",
+                        "MOC_from_url",
+                        "MOC_from_dict",
+                        "regions_stcs",
+                        "regions",
+                        "fits-image",
+                    ]
+                ).tag(sync=True),
+            },
+            help="A trait that keeps the history of the overlays added/removed "
+            "by the user. This is used to generate a synced view of ipyaladin "
+            "when exporting the notebook to static HTML files (e.g. when "
+            "generating the docs).",
+        ).tag(sync=True)
+    ).tag(sync=True)
+
+    _overlay_patch = traitlets.Dict(
+        traits={
+            "action": traitlets.Enum(["add", "remove"]).tag(sync=True),
+            "options": traitlets.Dict().tag(sync=True),
+            "data": traitlets.Union(
+                [
+                    # fits-image, astropy/numpy tables
+                    traitlets.Bytes(),
+                    # URLs of catalogs, MOCs
+                    traitlets.Unicode(),
+                    # JSON MOC
+                    traitlets.Dict(),
+                    # Sky regions (from stcs or astropy.regions objects)
+                    traitlets.List(trait=RegionInfos("")),
+                ]
+            ).tag(sync=True, **widgets.widget_serialization),
+            "type": traitlets.Enum(
+                [
+                    "table",
+                    "catalog_from_url",
+                    "MOC_from_url",
+                    "MOC_from_dict",
+                    "regions_stcs",
+                    "regions",
+                    "fits-image",
+                ]
+            ).tag(sync=True),
+        },
+        help="A private trait that registers the action made by the user "
+        "concerning the add/removing of overlays (MOC, table, fits image, regions).",
     ).tag(sync=True)
 
     _is_loaded = Bool(
@@ -679,6 +752,12 @@ class Aladin(anywidget.AnyWidget):
         """
         self.send({"event_name": "get_JPG_thumbnail"})
 
+    def _update_overlays(self, overlay_patch: dict) -> None:
+        self._overlay_patch = overlay_patch
+        # Update the canonical state as well.
+        # This is listened only when ipyaladin is run from a static HTML page
+        self.overlays = [*self.overlays, overlay_patch]
+
     @widget_should_be_loaded
     def add_catalog_from_URL(
         self, votable_URL: str, votable_options: Optional[dict] = None
@@ -693,10 +772,11 @@ class Aladin(anywidget.AnyWidget):
         """
         if votable_options is None:
             votable_options = {}
-        self.send(
+        self._update_overlays(
             {
-                "event_name": "add_catalog_from_URL",
-                "votable_URL": votable_URL,
+                "action": "add",
+                "type": "catalog_from_url",
+                "data": votable_URL,
                 "options": votable_options,
             }
         )
@@ -724,10 +804,13 @@ class Aladin(anywidget.AnyWidget):
             fits_bytes = io.BytesIO()
             fits.writeto(fits_bytes)
 
-        self._wcs = {}
-        self.send(
-            {"event_name": "add_fits", "options": image_options},
-            buffers=[fits_bytes.getvalue()],
+        self._update_overlays(
+            {
+                "action": "add",
+                "type": "fits-image",
+                "data": fits_bytes.getvalue(),
+                "options": image_options,
+            }
         )
 
     # MOCs
@@ -749,18 +832,20 @@ class Aladin(anywidget.AnyWidget):
 
         """
         if isinstance(moc, dict):
-            self.send(
+            self._update_overlays(
                 {
-                    "event_name": "add_MOC_from_dict",
-                    "moc_dict": moc,
+                    "action": "add",
+                    "type": "MOC_from_dict",
+                    "data": moc,
                     "options": moc_options,
                 }
             )
         elif isinstance(moc, str) and "://" in moc:
-            self.send(
+            self._update_overlays(
                 {
-                    "event_name": "add_MOC_from_URL",
-                    "moc_URL": moc,
+                    "action": "add",
+                    "type": "MOC_from_url",
+                    "data": moc,
                     "options": moc_options,
                 }
             )
@@ -769,10 +854,11 @@ class Aladin(anywidget.AnyWidget):
                 from mocpy import MOC  # noqa: PLC0415
 
                 if isinstance(moc, MOC):
-                    self.send(
+                    self._update_overlays(
                         {
-                            "event_name": "add_MOC_from_dict",
-                            "moc_dict": moc.serialize("json"),
+                            "action": "add",
+                            "type": "MOC_from_dict",
+                            "data": moc.serialize("json"),
                             "options": moc_options,
                         }
                     )
@@ -901,9 +987,13 @@ class Aladin(anywidget.AnyWidget):
             table_options["shape"] = shape
         table_bytes = io.BytesIO()
         table.write(table_bytes, format="votable")
-        self.send(
-            {"event_name": "add_table", "options": table_options},
-            buffers=[table_bytes.getvalue()],
+        self._update_overlays(
+            {
+                "action": "add",
+                "type": "table",
+                "options": table_options,
+                "data": table_bytes.getvalue(),
+            }
         )
 
     @widget_should_be_loaded
@@ -978,11 +1068,12 @@ class Aladin(anywidget.AnyWidget):
             # Define behavior for each region type
             regions_infos.append(RegionInfos(region_element).to_clean_dict())
 
-        self.send(
+        self._update_overlays(
             {
-                "event_name": "add_overlay",
-                "regions_infos": regions_infos,
-                "graphic_options": graphic_options,
+                "action": "add",
+                "type": "regions",
+                "options": graphic_options,
+                "data": regions_infos,
             }
         )
 
@@ -1042,12 +1133,12 @@ class Aladin(anywidget.AnyWidget):
             }
             for region_element in region_list
         ]
-
-        self.send(
+        self._update_overlays(
             {
-                "event_name": "add_overlay",
-                "regions_infos": regions_infos,
-                "graphic_options": overlay_options,
+                "action": "add",
+                "type": "regions_stcs",
+                "options": overlay_options,
+                "data": regions_infos,
             }
         )
 
@@ -1061,7 +1152,7 @@ class Aladin(anywidget.AnyWidget):
             The name of the color map to use.
 
         """
-        self.send({"event_name": "change_colormap", "colormap": color_map_name})
+        self.colormap = color_map_name
 
     def selection(self, selection_type: str = "rectangle") -> None:
         """Trigger the selection tool.

--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -217,7 +217,7 @@ class Aladin(anywidget.AnyWidget):
 
     overlays = traitlets.List(
         traitlets.Dict(
-            traits={
+            per_key_traits={
                 "action": traitlets.Enum(["add", "remove"]).tag(sync=True),
                 "options": traitlets.Dict().tag(sync=True),
                 "data": traitlets.Union(
@@ -252,7 +252,7 @@ class Aladin(anywidget.AnyWidget):
     ).tag(sync=True)
 
     _overlay_patch = traitlets.Dict(
-        traits={
+        per_key_traits={
             "action": traitlets.Enum(["add", "remove"]).tag(sync=True),
             "options": traitlets.Dict().tag(sync=True),
             "data": traitlets.Union(


### PR DESCRIPTION
This is based on the first cleanup done in #150

This contains:

* fix the documentation examples. overlays do correctly appear on the generated HTML static file because is its passed with traitlets instead of being sent with events.

current online documentation (no overlays are showed):

<img width="1491" height="816" alt="Capture d’écran 2025-08-27 à 17 10 22" src="https://github.com/user-attachments/assets/cb8fa772-5648-4083-92ae-30316d7a44c3" />


now:

<img width="1367" height="813" alt="Capture d’écran 2025-08-27 à 17 09 04" src="https://github.com/user-attachments/assets/068c6a72-853b-4bee-b2a1-4fe954057cc3" />


* if the user wants to export the aladin view to HTML, using `embed_minimal_html` from ipywidgets does recognize the add of overlays
To export the aladin object to html through ipywidgets:
```python
from ipywidgets.embed import embed_minimal_html

# drop_defaults is set to False because otherwise content of the widget's _esm is not put in the HTML
# See: https://github.com/manzt/anywidget/issues/339
embed_minimal_html('export.html', views=[aladin], drop_defaults=False)
```

This gives this html file with the table overlays correctly contained in it:
<img width="784" height="317" alt="Capture d’écran 2025-08-27 à 17 15 08" src="https://github.com/user-attachments/assets/0515988f-deaa-4798-be88-79016107b991" />


* add of colormap traitlet to replace the old event
* fix: projection change through the UI now change the value of the python traitlet (aladin.projection)