### PR TITLE
feat: adding multiple overlays via one call

### DIFF
--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -620,7 +620,7 @@ class Aladin(anywidget.AnyWidget):
 
         """
         try:
-            from astroquery.hips2fits import hips2fits  # noqa: PLC0415
+            from astroquery.hips2fits import hips2fits
         except ImportError as imp:
             raise ValueError(
                 "To use 'get_view_as_fits', you need astroquery. "
@@ -741,7 +741,7 @@ class Aladin(anywidget.AnyWidget):
             )
         else:
             try:
-                from mocpy import MOC  # noqa: PLC0415
+                from mocpy import MOC
 
                 if isinstance(moc, MOC):
                     self.send(
@@ -948,7 +948,7 @@ class Aladin(anywidget.AnyWidget):
                     "See the documentation for the supported region types."
                 )
 
-            from .utils._region_converter import RegionInfos  # noqa: PLC0415
+            from .utils._region_converter import RegionInfos
 
             # Define behavior for each region type
             regions_infos.append(RegionInfos(region_element).to_clean_dict())
@@ -986,11 +986,40 @@ class Aladin(anywidget.AnyWidget):
         )
         self.add_graphic_overlay_from_stcs(stc_string, **overlay_options)
 
+    def _vectorize_kwargs(self, n: int, **kwargs: any) -> None:
+        """Turn list/tuple kwargs into a list of n dicts.
+
+        Parameters
+        ----------
+        n: int
+            The length of the final list of dictionaries.
+        kwargs : keyword arguments
+            The overlay options for all the STC-S strings
+            See `Aladin Lite's graphic overlay options
+            <https://cds-astro.github.io/aladin-lite/A.html>`_
+        """
+        result = [{} for _ in range(n)]
+
+        for key, val in kwargs.items():
+            if isinstance(val, (list, tuple)):
+                if len(val) != n:
+                    raise ValueError(
+                        f"Option '{key}' has length {len(val)} but expected length {n}"
+                    )
+                for i in range(n):
+                    result[i][key] = val[i]
+            else:
+                raise TypeError(
+                    f"Option '{key}' has type {type(val)} but expected list/tuple"
+                )
+
+        return result
+
     @widget_should_be_loaded
     def add_graphic_overlay_from_stcs(
         self, stc_string: Union[Iterable[str], str], **overlay_options: any
     ) -> None:
-        """Add an overlay layer defined by an STC-S string.
+        """Add overlay layer(s) defined by STC-S string(s).
 
         Parameters
         ----------
@@ -1009,22 +1038,45 @@ class Aladin(anywidget.AnyWidget):
         """
         region_list = [stc_string] if isinstance(stc_string, str) else stc_string
 
-        regions_infos = [
-            {
-                "region_type": "stcs",
-                "infos": {"stcs": region_element},
-                "options": overlay_options,
-            }
-            for region_element in region_list
-        ]
+        if (
+            "name" in overlay_options
+            and type(overlay_options["name"]) is not str
+            and len(overlay_options["name"]) > 1
+        ):
+            overlay_options_list = self._vectorize_kwargs(
+                len(overlay_options["name"]), **overlay_options
+            )
+            regions_infos = [
+                [
+                    {
+                        "region_type": "stcs",
+                        "infos": {"stcs": region_list[x]},
+                        "options": overlay_options_list[x],
+                    }
+                ]
+                for x in range(len(region_list))
+            ]
+        else:
+            overlay_options_list = [overlay_options]
+            regions_infos = [
+                [
+                    {
+                        "region_type": "stcs",
+                        "infos": {"stcs": region_element},
+                        "options": overlay_options,
+                    }
+                    for region_element in region_list
+                ]
+            ]
 
-        self.send(
-            {
-                "event_name": "add_overlay",
-                "regions_infos": regions_infos,
-                "graphic_options": overlay_options,
-            }
-        )
+        for x in range(len(overlay_options_list)):
+            self.send(
+                {
+                    "event_name": "add_overlay",
+                    "regions_infos": regions_infos[x],
+                    "graphic_options": overlay_options_list[x],
+                }
+            )
 
     @widget_should_be_loaded
     def set_color_map(self, color_map_name: str) -> None:

--- a/src/tests/test_aladin.py
+++ b/src/tests/test_aladin.py
@@ -276,6 +276,63 @@ def test_add_graphic_overlay_from_stcs_noniterables(
     assert info.type is TypeError
 
 
+test_multiple_overlays = [
+    [
+        [
+            "POLYGON ICRS 257 38 261.005016 50.011125 278.305761 46.00127 257 38",
+            "CIRCLE ICRS 259.29230291 42.63394602 0.625",
+        ],
+        {
+            "name": ["first", "second"],
+            "color": ["blue", "pink"],
+            "linewidth": [2, 3],
+        },
+    ],
+    [
+        (
+            "CIRCLE ICRS 259.29230291 42.63394602 0.625",
+            "POLYGON ICRS 257 38 261.005016 50.011125 278.305761 46.00127 257 38",
+            "CIRCLE ICRS 259.29230291 42.63394602 0.625",
+        ),
+        {
+            "name": ["circle", "polygon", "circle2"],
+            "color": ["red", "blue", "yellow"],
+            "linewidth": [4, 5, 6],
+        },
+    ],
+]
+
+
+@pytest.mark.parametrize("info", test_multiple_overlays)
+def test_add_graphic_overlays_from_stcs_iterables(
+    monkeypatch: Callable,
+    info: Iterable,
+) -> None:
+    """Test generating multiple region overlay infos from iterable STC-S string(s).
+
+    Parameters
+    ----------
+    info : Iterable[Iterable, dict]
+        A list of the stcs strings to create region overlay infos from and the
+        associated overlay options.
+
+    """
+    mock_send = Mock()
+    monkeypatch.setattr(Aladin, "send", mock_send)
+
+    stcs_strings = info[0]
+    options = info[1]
+
+    aladin.add_graphic_overlay_from_stcs(stcs_strings, **options)
+    for x in range(len(mock_send.call_args_list)):
+        regions_info = mock_send.call_args_list[x][0][0]["regions_infos"]
+        assert isinstance(regions_info, list)
+        assert regions_info[0]["infos"]["stcs"] == stcs_strings[x]
+        assert regions_info[0]["options"]["name"] == options["name"][x]
+        assert regions_info[0]["options"]["color"] == options["color"][x]
+        assert regions_info[0]["options"]["linewidth"] == options["linewidth"][x]
+
+
 def test_add_table(monkeypatch: Callable) -> None:
     """Test generating region overlay info from iterable STC-S string(s).
 
@@ -318,3 +375,113 @@ def test_add_table(monkeypatch: Callable) -> None:
         "conversion_maj_axis": 1,
     }
     assert table_sent_message["options"]["ellipse_error"] == ellipse_options
+
+
+test_options_list = [
+    {
+        "name": ["polygon", "polygon2"],
+        "color": ["blue", "pink"],
+        "linewidth": [3, 7],
+        "num_entries": 2,
+    },
+    {
+        "name": ["circle", "poly", "circle_2"],
+        "color": ["blue", "pink", "yellow"],
+        "linewidth": [3, 4, 5],
+        "num_entries": 3,
+    },
+]
+
+
+@pytest.mark.parametrize("options", test_options_list)
+def test_vectorize_kwargs(
+    options: dict,
+) -> None:
+    """Test proper parsing for kwargs of lists.
+
+    Parameters
+    ----------
+    options : dict
+        The dictionary of overlay options.
+    """
+    num_entries = options.pop("num_entries")
+    last_ind = num_entries - 1
+    options_list = aladin._vectorize_kwargs(num_entries, **options)
+
+    assert len(options_list) == num_entries
+    assert options_list[0]["name"] == options["name"][0]
+    assert options_list[last_ind]["name"] == options["name"][last_ind]
+    assert options_list[0]["color"] == options["color"][0]
+    assert options_list[last_ind]["linewidth"] == options["linewidth"][last_ind]
+
+
+test_invalid_types_options_list = [
+    {
+        "name": ["polygon", "polygon2"],
+        "color": ["blue", "pink"],
+        "linewidth": 3,
+        "num_entries": 2,
+    },
+    {
+        "name": "polygon",
+        "color": ["blue", "pink", "yellow"],
+        "linewidth": [3, 4, 5],
+        "num_entries": 3,
+    },
+]
+
+
+@pytest.mark.parametrize("options", test_invalid_types_options_list)
+def test_vectorize_kwargs_wrong_type(
+    options: dict,
+) -> None:
+    """Test TypeError raised when parsing non-list/tuple kwargs.
+
+    Parameters
+    ----------
+    options : dict
+        The dictionary of overlay options.
+    """
+    num_entries = options.pop("num_entries")
+
+    with pytest.raises(TypeError) as info:
+        aladin._vectorize_kwargs(num_entries, **options)
+
+    assert info.type is TypeError
+    assert "but expected list/tuple" in str(info.value)
+
+
+test_invalid_len_options_list = [
+    {
+        "name": ["polygon", "polygon2"],
+        "color": ["blue", "pink"],
+        "linewidth": [3],
+        "num_entries": 2,
+    },
+    {
+        "name": ["polygon"],
+        "color": ["blue", "pink", "yellow"],
+        "linewidth": [3, 4, 5],
+        "num_entries": 3,
+    },
+]
+
+
+@pytest.mark.parametrize("options", test_invalid_len_options_list)
+def test_vectorize_kwargs_invalid_len(
+    options: dict,
+) -> None:
+    """Test ValueError raised when parsing wrong length list for kwarg.
+
+    Parameters
+    ----------
+    options : dict
+        The dictionary of overlay options.
+    """
+    num_entries = options.pop("num_entries")
+
+    with pytest.raises(ValueError) as info:
+        aladin._vectorize_kwargs(num_entries, **options)
+
+    assert info.type is ValueError
+    assert f"but expected length {num_entries}" in str(info.value)


### PR DESCRIPTION
This adds support for lists of s_regions, names, and styles when adding overlays via `add_graphic_overlay_from_stcs`. Related PR from issue #167. Users can pass lists of kwargs for overlay options to create multiple unique overlays (one for each footprint) instead of one overlay with multiple footprints. I went with a python-based approach to allow for easier integration with overlay management (upcoming PR), easier testing, and to maintain the general theme of one sent message = one overlay in the code. I am very open to changes and a different approach if that's preferable! Let me know if you would prefer a different approach.

Side note: I am not sure why ruff is removing the # noqa: PLC0415 from lines 623, 744, 951. Have you seen this before? Should I add them back in?