### PR TITLE
feature: overlay manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
 - `projection` parameter can now be called to change the projection of the
   ipyaladin viewer [#172]
+- introduction of overlay manager that tracks the overlays users add to and
+  remove from the widget through both the GUI and API [#174]
 
 ## [0.7.0]
 

--- a/examples/02_Base_Commands.ipynb
+++ b/examples/02_Base_Commands.ipynb
@@ -251,9 +251,46 @@
     "            ),\n",
     "        )\n",
     "    )\n",
-    "aladin.add_markers(markers, name=\"M1-M10\", color=\"pink\", shape=\"cross\", source_size=15)\n",
+    "markers_overlay = aladin.add_markers(\n",
+    "    markers, name=\"M1-M10\", color=\"pink\", shape=\"cross\", source_size=15\n",
+    ")\n",
     "aladin.target = \"M1\"\n",
     "aladin.fov = 0.2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can update the style of the markers by calling `.update()` and providing the options you want to change for the overlay. See possible options at https://cds-astro.github.io/aladin-lite/global.html#CatalogOptions.\n",
+    "You can also get a list of all of the overlays in the widget by calling `.overlays`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "markers_overlay = markers_overlay.update(color=\"blue\", source_size=20)\n",
+    "aladin.overlays"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can remove the markers by calling `.remove_overlay()`, which accepts the Overlay object or the string name of the object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin.remove_overlay(markers_overlay)\n",
+    "aladin.overlays  # which no longer contains the M1-M10 markers"
    ]
   }
  ],

--- a/examples/03_Functions.ipynb
+++ b/examples/03_Functions.ipynb
@@ -54,7 +54,7 @@
     "    \"DEJ&-oc.form=dm&-out.meta=DhuL&-out.max=9999&-c.rm=180\"\n",
     ")\n",
     "options = {\"source_size\": 12, \"color\": \"#f08080\", \"on_click\": \"showTable\"}\n",
-    "aladin.add_catalog_from_URL(url, options)"
+    "catalog = aladin.add_catalog_from_URL(url, options)"
    ]
   },
   {

--- a/examples/04_Importing_Tables.ipynb
+++ b/examples/04_Importing_Tables.ipynb
@@ -75,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "aladin.add_table(\n",
+    "table_overlay = aladin.add_table(\n",
     "    table,\n",
     "    shape=EllipseError(\n",
     "        maj_axis=\"coo_err_maj\",\n",
@@ -97,7 +97,18 @@
    "source": [
     "If you zoom in the view, you'll remark that the sources which had error information appear as ellipses. If if there is no information in the error columns, then the sources appear with the fallback shape `default_shape`. `default_shape` should be one of the strings allowed in `shape`.\n",
     "\n",
-    "If the ellipse would be too small to be drawn in the widget, then it appears as a square, see the source `2MASS J05343561+2200372` located in `83.64842925852 +22.01034559457`. If you zoom in close to this square, you'll see the square turning into an ellipse when it is big enough to be drawn."
+    "If the ellipse would be too small to be drawn in the widget, then it appears as a square, see the source `2MASS J05343561+2200372` located in `83.64842925852 +22.01034559457`. If you zoom in close to this square, you'll see the square turning into an ellipse when it is big enough to be drawn.\n",
+    "\n",
+    "If you want to change the appearance of the markers, call `.update()` and provide the options you want to change for the overlay. See possible options at https://cds-astro.github.io/aladin-lite/global.html#CatalogOptions. Run the cell below to increase the source size and make the hover color red."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table_overlay = table_overlay.update(hover_color=\"red\", source_size=30)"
    ]
   },
   {
@@ -126,7 +137,7 @@
     "    meta={\"name\": \"my_sample_table\"},\n",
     ")\n",
     "\n",
-    "aladin.add_table(\n",
+    "qtable_overlay = aladin.add_table(\n",
     "    t,\n",
     "    name=t.meta[\"name\"],\n",
     "    shape=CircleError(\n",

--- a/examples/05_Display_a_MOC.ipynb
+++ b/examples/05_Display_a_MOC.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "aladin.add_moc(\n",
+    "moc_from_url = aladin.add_moc(\n",
     "    \"https://alasky.u-strasbg.fr/footprints/tables/vizier/II_337_vvv1/MOC?nside=256\",\n",
     "    color=\"violet\",\n",
     "    opacity=0.3,\n",
@@ -263,7 +263,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "aladin.add_moc(moc)"
+    "moc_from_dict = aladin.add_moc(moc)"
    ]
   },
   {
@@ -286,7 +286,94 @@
     "    external_radius=20 * u.deg,\n",
     "    max_depth=16,\n",
     ")\n",
-    "aladin.add_moc(moc, color=\"teal\", edge=True, line_width=3, fill=True, opacity=0.5)"
+    "moc_from_mocpy = aladin.add_moc(\n",
+    "    moc, color=\"teal\", edge=True, line_width=3, fill=True, opacity=0.5\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can visually check in the widget that all of the MOCs were added, and we can call the following to get the names of the mocs we added."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin.overlays"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you want to further distinguish which MOC is which, try calling `.update()` with any options you want to change for the MOC. See possible options at https://cds-astro.github.io/aladin-lite/global.html#MOCOptions \n",
+    "\n",
+    "Run the cell below to update the name, fill, and color of `moc_from_dict`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "moc_from_dict = moc_from_dict.update(name=\"moc_from_dict\", color=\"green\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By running the following cell, we can confirm that our re-naming worked (we now see `moc_from_dict` instead of `moc_1`). You can see the same re-naming by opening the widget's overlays menu."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin.overlays"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you forget which parameters you set for a given overlay, you can call the `Overlay` object to get a dictionary of the parameters you set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "moc_from_url"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or, you can run the following cell to get more specific details about an `Overlay` instead of the summary dictionary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"overlay name:\", moc_from_url.name)\n",
+    "print(\"overlay type:\", moc_from_url.type)\n",
+    "print(\"overlay options:\", moc_from_url.options)\n",
+    "print(\"overlay data:\", moc_from_url.data)"
    ]
   }
  ],

--- a/examples/08_Rectangular-selection.ipynb
+++ b/examples/08_Rectangular-selection.ipynb
@@ -67,7 +67,7 @@
    "outputs": [],
    "source": [
     "table = Simbad.query_region(\"M 1\", radius=0.1 * u.deg)\n",
-    "aladin.add_table(table)\n",
+    "table_overlay = aladin.add_table(table)\n",
     "\n",
     "\n",
     "def process_result(sources: dict) -> None:\n",

--- a/examples/09_Displaying_Shapes.ipynb
+++ b/examples/09_Displaying_Shapes.ipynb
@@ -54,7 +54,7 @@
    "outputs": [],
    "source": [
     "aladin = Aladin(target=\"M 51\", fov=1.2)\n",
-    "aladin.add_graphic_overlay_from_stcs(\n",
+    "polygon_overlay = aladin.add_graphic_overlay_from_stcs(\n",
     "    \"\"\"Polygon ICRS 202.63748 47.24951 202.46382 47.32391 202.46379 47.32391 202.45459\n",
     "    47.32391 202.34527 47.20597 202.34527 47.20596 202.34529 47.19710 202.51870\n",
     "    47.12286 202.52789 47.12286 202.52791 47.12286 202.63746 47.24063 202.63749\n",
@@ -66,7 +66,7 @@
     "    47.00226 202.52539 47.12018\"\"\",\n",
     "    color=\"red\",\n",
     ")\n",
-    "aladin.add_graphic_overlay_from_stcs(\n",
+    "circle_overlay = aladin.add_graphic_overlay_from_stcs(\n",
     "    \"Circle ICRS 202.4656816 +47.1999842 0.04\", color=\"#4488ee\"\n",
     ")\n",
     "\n",
@@ -182,7 +182,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "aladin.add_graphic_overlay_from_region([circle, ellipse, line, polygon, rectangle])"
+    "regions_overlay = aladin.add_graphic_overlay_from_region(\n",
+    "    [circle, ellipse, line, polygon, rectangle]\n",
+    ")"
    ]
   },
   {

--- a/examples/11_Extracting_information_from_the_view.ipynb
+++ b/examples/11_Extracting_information_from_the_view.ipynb
@@ -177,8 +177,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "aladin.add_table(simbad, name=\"simbad\", color=\"purple\", shape=\"circle\", source_size=20)\n",
-    "aladin.add_table(usno, name=\"usno\", color=\"teal\", shape=\"square\", source_size=20)\n",
+    "simbad_overlay = aladin.add_table(\n",
+    "    simbad, name=\"simbad\", color=\"purple\", shape=\"circle\", source_size=20\n",
+    ")\n",
+    "usno_overlay = aladin.add_table(\n",
+    "    usno, name=\"usno\", color=\"teal\", shape=\"square\", source_size=20\n",
+    ")\n",
     "aladin.target = m1\n",
     "aladin.fov = 0.3\n",
     "aladin.survey = \"CDS/P/PanSTARRS/DR1/g\""

--- a/examples/12_Planetary_surveys.ipynb
+++ b/examples/12_Planetary_surveys.ipynb
@@ -168,7 +168,7 @@
     "]\n",
     "\n",
     "table = Table([longitudes, latitudes, names], names=(\"Longitude\", \"Latitude\", \"Name\"))\n",
-    "mars.add_table(\n",
+    "features_overlay = mars.add_table(\n",
     "    table, color=\"#67d38d\", source_size=15, shape=\"cross\", name=\"Mars_features\"\n",
     ")"
    ]

--- a/js/models/event_handler.js
+++ b/js/models/event_handler.js
@@ -196,6 +196,21 @@ export default class EventHandler {
       }
     });
 
+    this.aladin.on("stackChanged", (state) => {
+      // ignoring any layer that is NOT an overlay
+      if (!state || !state.overlay) return;
+      const overlay = state.overlay;
+      const content = {
+        name: overlay.name,
+        type: overlay.type,
+        change: state.change,
+      };
+      this.model.send({
+        event_type: "stack_changed",
+        content: content,
+      });
+    });
+
     this.aladin.on("click", (clickContent) => {
       this.model.send({
         event_type: "click",
@@ -340,6 +355,7 @@ export default class EventHandler {
       add_MOC_from_URL: this.messageHandler.handleAddMOCFromURL,
       add_MOC_from_dict: this.messageHandler.handleAddMOCFromDict,
       add_overlay: this.messageHandler.handleAddOverlay,
+      remove_overlay: this.messageHandler.handleRemoveOverlay,
       change_colormap: this.messageHandler.handleChangeColormap,
       get_JPG_thumbnail: this.messageHandler.handleGetJPGThumbnail,
       trigger_selection: this.messageHandler.handleTriggerSelection,

--- a/js/models/message_handler.js
+++ b/js/models/message_handler.js
@@ -132,6 +132,13 @@ export default class MessageHandler {
     }
   }
 
+  handleRemoveOverlay = (msg) => {
+    const overlay_names = msg["overlay_names"];
+    for (const overlay_name of overlay_names) {
+      this.aladin.removeOverlay(overlay_name);
+    }
+  };
+
   handleChangeColormap(msg) {
     this.aladin.getBaseImageLayer().setColormap(msg["colormap"]);
   }

--- a/src/ipyaladin/overlays/overlay.py
+++ b/src/ipyaladin/overlays/overlay.py
@@ -1,0 +1,111 @@
+from enum import Enum
+
+
+class OverlayType(Enum):
+    """Overlay types enum."""
+
+    MARKER = "marker"
+    CATALOG = "catalog"
+    MOC = "moc"
+    TABLE = "table"
+    OVERLAY_REGION = "overlay_region"
+    OVERLAY_STCS = "overlay_stcs"
+    JAVASCRIPT = "javascript"
+
+
+class Overlay(dict):
+    """Overlay class.
+
+    This creates a dictionary with overlay properties for easy reference and
+    interaction.
+    """
+
+    def __init__(self, overlay_info: dict, aladin: object) -> None:
+        self.app = aladin
+        overlay_type = overlay_info.get("type")
+        if overlay_type not in {t.value for t in OverlayType}:
+            raise ValueError(
+                f"Invalid overlay type '{overlay_type}'. "
+                f"Must be one of {[t.value for t in OverlayType]}."
+            )
+        super().__init__(overlay_info)
+
+    @property
+    def type(self) -> OverlayType:
+        """Returns OverlayType."""
+        return self.get("type")
+
+    @property
+    def options(self) -> dict:
+        """Returns overlay options."""
+        return self.get("options")
+
+    @property
+    def name(self) -> str:
+        """Returns overlay name."""
+        return self.options.get("name")
+
+    @property
+    def data(self) -> dict:
+        """Returns overlay data."""
+        ignored = ["type", "options"]
+        return {key: value for key, value in self.items() if key not in ignored}
+
+    def update(self, **new_options: any) -> dict:
+        """Update overlay with new options.
+
+        Parameters
+        ----------
+        new_options : any
+            The arguments to update on the overlay.
+        """
+        if self.type == OverlayType.JAVASCRIPT.value:
+            raise TypeError(
+                f"Cannot update overlay `{self.name}` since it was added via "
+                "GUI. Use GUI-based interactions to update."
+            )
+
+        if not new_options:
+            raise ValueError(
+                f"Cannot update overlay `{self.name}` since no options to "
+                "update were provided."
+            )
+
+        self.app.remove_overlay(self)
+        updated_options = {**self.options, **new_options}
+
+        if self.type == OverlayType.MARKER.value:
+            markers = self.get("update_info")
+            overlay_info = self.app.add_markers(markers, **updated_options)
+        elif self.type == OverlayType.CATALOG.value:
+            overlay_info = self.app.add_catalog_from_URL(
+                self["votable_URL"], updated_options
+            )
+        elif self.type == OverlayType.MOC.value:
+            overlay_info = self.app.add_moc(self["moc"], **updated_options)
+        elif self.type == OverlayType.TABLE.value:
+            shape = updated_options.pop("shape", self.options.get("shape", "cross"))
+
+            overlay_info = self.app.add_table(
+                self["table"], shape=shape, **updated_options
+            )
+        elif self.type == OverlayType.OVERLAY_REGION.value:
+            regions = self["update_info"]
+            new_regions = []
+            for region in regions:
+                style = self.options.copy()
+                if "color" in style:
+                    style["edgecolor"] = style["color"]
+                style.pop("name", None)
+                region.visual.update(style)
+                new_regions.append(region)
+            overlay_info = self.app.add_graphic_overlay_from_region(
+                regions, **updated_options
+            )
+        elif self.type == OverlayType.OVERLAY_STCS.value:
+            update_info = self["update_info"]
+            overlay_info = self.app.add_graphic_overlay_from_stcs(
+                update_info, **updated_options
+            )
+
+        return overlay_info

--- a/src/ipyaladin/overlays/overlay_manager.py
+++ b/src/ipyaladin/overlays/overlay_manager.py
@@ -1,0 +1,105 @@
+import warnings
+from .overlay import Overlay
+
+
+class OverlayManager:
+    """OverlayManager class.
+
+    This creates standard handling for Overlay objects.
+    """
+
+    def __init__(self, aladin: object) -> None:
+        self.app = aladin
+        self._overlays_dict = {}
+
+    def __setitem__(self, key: str, value: any) -> None:
+        self._overlays_dict[key] = value
+
+    def __getitem__(self, key: str) -> str:
+        return self._overlays_dict[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._overlays_dict
+
+    def items(self) -> dict:
+        """Return overlays in manager."""
+        return self._overlays_dict.items()
+
+    def pop(self, key: str) -> None:
+        """Remove overlay from manager."""
+        self._overlays_dict.pop(key)
+
+    def keys(self) -> list:
+        """Return names of overlays in manager."""
+        return self._overlays_dict.keys()
+
+    def make_unique_name(self, name: str) -> str:
+        """Create a unique overlay name.
+
+        Parameters
+        ----------
+        name : str
+            The current name of the overlay to be added to the widget.
+
+        Returns
+        -------
+        unique_name
+            A string that is a unique name for the overlay being added.
+        """
+        unique_name = name
+        i = 1
+
+        while unique_name in self._overlays_dict:
+            unique_name = f"{name}_{i}"
+            i += 1
+
+        return unique_name
+
+    def common_overlay_handling(self, overlay_options: dict, default_name: str) -> dict:
+        """Handle common functionality across added overlay methods.
+
+        Parameters
+        ----------
+        overlay_options : dict
+            The dictionary of overlay options for the overlay being added to the widget.
+        default_name : str
+            The default name of the overlay being added.
+
+        Returns
+        -------
+        overlay_options
+            The updated dictionary of overlay options for the overlay being added
+            to the widget.
+        """
+        name = overlay_options.get("name", default_name)
+        unique_name = self.make_unique_name(name=name)
+        overlay_options["name"] = unique_name
+
+        if name not in {unique_name, default_name}:
+            warnings.warn(
+                f"Overlay name `{name}` is already in use. Name `{unique_name}` "
+                "will be used instead.",
+                stacklevel=2,
+            )
+
+        return overlay_options
+
+    def add_overlay(self, overlay_info: dict) -> dict:
+        """Add overlay to overlay dictionary.
+
+        Parameters
+        ----------
+        overlay_info : dict
+            The dictionary of overlay info for the overlay being added to the widget.
+            Includes overlay options and specific overlay info (URLs, coords, etc.).
+
+        Returns
+        -------
+        overlay_info
+            The overlay options for the overlay being added to the widget.
+        """
+        overlay_info = Overlay(overlay_info, self.app)
+
+        self[overlay_info["options"]["name"]] = overlay_info
+
+        return overlay_info

--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -40,6 +40,8 @@ from .elements.error_shape import (
     _error_radius_conversion_factor,
 )
 from .elements.marker import Marker
+from .overlays.overlay_manager import OverlayManager
+from .overlays.overlay import Overlay
 
 try:
     from regions import (
@@ -276,6 +278,9 @@ class Aladin(anywidget.AnyWidget):
         for prop in properties:
             setattr(self, prop, getattr(self, f"_{prop}"))
 
+        # initialize overlay
+        self._overlay_manager = OverlayManager(self)
+
         self.on_msg(self._handle_custom_message)
 
         def on_load_change(change: traitlets.Dict) -> None:
@@ -307,6 +312,40 @@ class Aladin(anywidget.AnyWidget):
             self.listener_callback["select"](message["content"])
         elif event_type == "save_view_as_image":
             self._save_file(message["path"], buffers[0])
+        elif event_type == "stack_changed":
+            content = message["content"]
+            if content["change"] == "removed":
+                self.handle_overlay_removed(content["name"])
+            elif content["change"] == "added":
+                self.handle_overlay_added(content["name"], content["type"])
+
+    def handle_overlay_removed(self, overlay_name: str) -> None:
+        """Remove overlay from _overlay_manager dict."""
+        if overlay_name in self._overlay_manager:
+            self._overlay_manager.pop(overlay_name)
+
+    def handle_overlay_added(self, overlay_name: str, aladin_type: str) -> None:
+        """Add overlay into _overlay_manager dict."""
+        if overlay_name not in self._overlay_manager:
+            # defining type as javascript to indicate layer was added via GUI
+            overlay_info = {
+                "type": "javascript",
+                "options": {"name": overlay_name, "aladin_type": aladin_type},
+            }
+            self._overlay_manager.add_overlay(overlay_info)
+
+    def _send_or_queue(
+        self, message: dict, buffers: Optional[list[Any]] = None
+    ) -> None:
+        if not self._is_loaded:
+            self._call_store.add(
+                self.send,
+                message,
+                buffers=buffers,
+            )
+            return
+
+        self.send(message, buffers=buffers)
 
     @property
     def selected_objects(self) -> List[Table]:
@@ -324,6 +363,17 @@ class Aladin(anywidget.AnyWidget):
             if objects_data:
                 catalogs.append(Table(objects_data))
         return catalogs
+
+    @property
+    def overlays(self) -> List:
+        """The list of overlays on the widget.
+
+        Returns
+        -------
+        list
+            A list of strings representing the widget overlays.
+        """
+        return list(self._overlay_manager.keys())
 
     @property
     def height(self) -> int:
@@ -570,13 +620,28 @@ class Aladin(anywidget.AnyWidget):
         """
         if not isinstance(markers, list):
             markers = [markers]
-        self.send(
+
+        catalog_options = self._overlay_manager.common_overlay_handling(
+            catalog_options, "catalog"
+        )
+
+        overlay_info = self._overlay_manager.add_overlay(
+            {
+                "type": "marker",
+                "markers": [marker.__dict__ for marker in markers],
+                "update_info": markers,
+                "options": catalog_options,
+            }
+        )
+
+        self._send_or_queue(
             {
                 "event_name": "add_marker",
                 "markers": [marker.__dict__ for marker in markers],
                 "options": catalog_options,
             }
         )
+        return overlay_info
 
     def _save_file(self, path: str, buffer: bytes) -> None:
         """Save a file from a buffer.
@@ -679,7 +744,6 @@ class Aladin(anywidget.AnyWidget):
         """
         self.send({"event_name": "get_JPG_thumbnail"})
 
-    @widget_should_be_loaded
     def add_catalog_from_URL(
         self, votable_URL: str, votable_options: Optional[dict] = None
     ) -> None:
@@ -693,13 +757,28 @@ class Aladin(anywidget.AnyWidget):
         """
         if votable_options is None:
             votable_options = {}
-        self.send(
+
+        votable_options = self._overlay_manager.common_overlay_handling(
+            votable_options, "catalog"
+        )
+
+        overlay_info = self._overlay_manager.add_overlay(
+            {
+                "type": "catalog",
+                "votable_URL": votable_URL,
+                "options": votable_options,
+            }
+        )
+
+        self._send_or_queue(
             {
                 "event_name": "add_catalog_from_URL",
                 "votable_URL": votable_URL,
                 "options": votable_options,
             }
         )
+
+        return overlay_info
 
     @widget_should_be_loaded
     def add_fits(self, fits: Union[str, Path, HDUList], **image_options: any) -> None:
@@ -732,7 +811,6 @@ class Aladin(anywidget.AnyWidget):
 
     # MOCs
 
-    @widget_should_be_loaded
     def add_moc(self, moc: any, **moc_options: any) -> None:
         """Add a MOC to the Aladin-Lite widget.
 
@@ -748,8 +826,18 @@ class Aladin(anywidget.AnyWidget):
             options <https://cds-astro.github.io/aladin-lite/global.html#MOCOptions>`_
 
         """
+        moc_options = self._overlay_manager.common_overlay_handling(moc_options, "moc")
+
         if isinstance(moc, dict):
-            self.send(
+            overlay_info = self._overlay_manager.add_overlay(
+                {
+                    "type": "moc",
+                    "moc": moc,
+                    "options": moc_options,
+                }
+            )
+
+            self._send_or_queue(
                 {
                     "event_name": "add_MOC_from_dict",
                     "moc_dict": moc,
@@ -757,7 +845,15 @@ class Aladin(anywidget.AnyWidget):
                 }
             )
         elif isinstance(moc, str) and "://" in moc:
-            self.send(
+            overlay_info = self._overlay_manager.add_overlay(
+                {
+                    "type": "moc",
+                    "moc": moc,
+                    "options": moc_options,
+                }
+            )
+
+            self._send_or_queue(
                 {
                     "event_name": "add_MOC_from_URL",
                     "moc_URL": moc,
@@ -769,10 +865,20 @@ class Aladin(anywidget.AnyWidget):
                 from mocpy import MOC  # noqa: PLC0415
 
                 if isinstance(moc, MOC):
-                    self.send(
+                    moc_dict = moc.serialize("json")
+
+                    overlay_info = self._overlay_manager.add_overlay(
+                        {
+                            "type": "moc",
+                            "moc": moc_dict,
+                            "options": moc_options,
+                        }
+                    )
+
+                    self._send_or_queue(
                         {
                             "event_name": "add_MOC_from_dict",
-                            "moc_dict": moc.serialize("json"),
+                            "moc_dict": moc_dict,
                             "options": moc_options,
                         }
                     )
@@ -783,7 +889,8 @@ class Aladin(anywidget.AnyWidget):
                     "library with 'pip install mocpy'."
                 ) from imp
 
-    @widget_should_be_loaded
+        return overlay_info
+
     def add_moc_from_URL(
         self, moc_URL: str, moc_options: Optional[dict] = None
     ) -> None:
@@ -809,7 +916,6 @@ class Aladin(anywidget.AnyWidget):
             moc_options = {}
         self.add_moc(moc_URL, **moc_options)
 
-    @widget_should_be_loaded
     def add_moc_from_dict(
         self, moc_dict: dict, moc_options: Optional[dict] = None
     ) -> None:
@@ -836,7 +942,6 @@ class Aladin(anywidget.AnyWidget):
             moc_options = {}
         self.add_moc(moc_dict, **moc_options)
 
-    @widget_should_be_loaded
     def add_table(
         self,
         table: Union[QTable, Table],
@@ -901,12 +1006,26 @@ class Aladin(anywidget.AnyWidget):
             table_options["shape"] = shape
         table_bytes = io.BytesIO()
         table.write(table_bytes, format="votable")
-        self.send(
+
+        table_options = self._overlay_manager.common_overlay_handling(
+            table_options, "catalog"
+        )
+
+        overlay_info = self._overlay_manager.add_overlay(
+            {
+                "type": "table",
+                "table": table,
+                "options": table_options,
+            }
+        )
+
+        self._send_or_queue(
             {"event_name": "add_table", "options": table_options},
             buffers=[table_bytes.getvalue()],
         )
 
-    @widget_should_be_loaded
+        return overlay_info
+
     def add_graphic_overlay_from_region(
         self,
         region: SupportedRegion,
@@ -978,7 +1097,20 @@ class Aladin(anywidget.AnyWidget):
             # Define behavior for each region type
             regions_infos.append(RegionInfos(region_element).to_clean_dict())
 
-        self.send(
+        graphic_options = self._overlay_manager.common_overlay_handling(
+            graphic_options, "region"
+        )
+
+        overlay_info = self._overlay_manager.add_overlay(
+            {
+                "type": "overlay_region",
+                "regions_infos": regions_infos,
+                "update_info": region_list,
+                "options": graphic_options,
+            }
+        )
+
+        self._send_or_queue(
             {
                 "event_name": "add_overlay",
                 "regions_infos": regions_infos,
@@ -986,7 +1118,8 @@ class Aladin(anywidget.AnyWidget):
             }
         )
 
-    @widget_should_be_loaded
+        return overlay_info
+
     def add_overlay_from_stcs(
         self, stc_string: Union[Iterable[str], str], **overlay_options: any
     ) -> None:
@@ -1011,7 +1144,6 @@ class Aladin(anywidget.AnyWidget):
         )
         self.add_graphic_overlay_from_stcs(stc_string, **overlay_options)
 
-    @widget_should_be_loaded
     def add_graphic_overlay_from_stcs(
         self, stc_string: Union[Iterable[str], str], **overlay_options: any
     ) -> None:
@@ -1032,6 +1164,10 @@ class Aladin(anywidget.AnyWidget):
         object.
 
         """
+        overlay_options = self._overlay_manager.common_overlay_handling(
+            overlay_options, "stcs_region"
+        )
+
         region_list = [stc_string] if isinstance(stc_string, str) else stc_string
 
         regions_infos = [
@@ -1043,11 +1179,63 @@ class Aladin(anywidget.AnyWidget):
             for region_element in region_list
         ]
 
-        self.send(
+        overlay_info = self._overlay_manager.add_overlay(
+            {
+                "type": "overlay_stcs",
+                "regions_infos": regions_infos,
+                "update_info": region_list,
+                "options": overlay_options,
+            }
+        )
+
+        self._send_or_queue(
             {
                 "event_name": "add_overlay",
                 "regions_infos": regions_infos,
                 "graphic_options": overlay_options,
+            }
+        )
+
+        return overlay_info
+
+    def remove_overlay(
+        self, overlay: Union[Iterable[str, Overlay], str, Overlay]
+    ) -> None:
+        """Remove an overlay layer defined by a string.
+
+        Parameters
+        ----------
+        overlay : str(s) or Overlay(s)
+            The overlay name (str) or Overlay object to be removed.
+
+        Raises
+        ------
+        TypeError
+            Overlays are not provided as Overlay or names.
+        ValueError
+            Overlay does not exist.
+        """
+        if isinstance(overlay, Overlay):
+            overlay_names = [overlay.name]
+        elif isinstance(overlay, str):
+            overlay_names = [overlay]
+        elif isinstance(overlay, (list, tuple)):
+            overlay_names = [o.name if isinstance(o, Overlay) else o for o in overlay]
+        else:
+            raise TypeError("overlay must be a str, Overlay, or iterable of these.")
+
+        for name in overlay_names:
+            if name not in self._overlay_manager:
+                raise ValueError(
+                    f"Cannot remove overlay `{name}` since this layer does not exist."
+                )
+
+            self._overlay_manager.pop(name)
+
+        self._send_or_queue(
+            {
+                "event_name": "remove_overlay",
+                "overlay_names": overlay_names,
             }
         )
 
@@ -1102,7 +1290,7 @@ class Aladin(anywidget.AnyWidget):
         Parameters
         ----------
         listener_type : str
-            Can either be 'object_hovered', 'object_clicked', 'click' or 'select'
+            Can either be 'object_hovered', 'object_clicked', 'click', or 'select'
         callback : Callable
             A python function to be called when the event corresponding to the
             listener_type is detected
@@ -1119,7 +1307,7 @@ class Aladin(anywidget.AnyWidget):
         else:
             raise ValueError(
                 "listener_type must be 'object_hovered', "
-                "'object_clicked', 'click' or 'select'"
+                "'object_clicked', 'click', or 'select'"
             )
 
     @widget_should_be_loaded

--- a/src/tests/test_aladin.py
+++ b/src/tests/test_aladin.py
@@ -318,3 +318,48 @@ def test_add_table(monkeypatch: Callable) -> None:
         "conversion_maj_axis": 1,
     }
     assert table_sent_message["options"]["ellipse_error"] == ellipse_options
+
+
+test_overlay_names = [
+    "overlay",
+    ["overlay", "overlay_1", "2MASS"],
+    "cat",
+    ["overlay_1", "2MASS"],
+]
+
+
+@pytest.mark.parametrize("overlay_names", test_overlay_names)
+def test_remove_overlay(
+    monkeypatch: Callable,
+    overlay_names: Union[Iterable[str], str],
+) -> None:
+    """Test proper messages sent for removing overlays using their name string(s).
+
+    Parameters
+    ----------
+    overlay_names : Union[Iterable[str], str]
+        The name strings of overlays.
+    """
+    adding_overlay_list = (
+        [overlay_names] if isinstance(overlay_names, str) else overlay_names
+    )
+
+    for overlay_name in adding_overlay_list:
+        aladin.add_graphic_overlay_from_stcs(
+            "CIRCLE ICRS 259.29230291 42.63394602 0.625", name=overlay_name
+        )
+
+    mock_send = Mock()
+    monkeypatch.setattr(Aladin, "send", mock_send)
+    aladin.remove_overlay(overlay_names)
+
+    event_name = mock_send.call_args[0][0]["event_name"]
+    assert isinstance(event_name, str)
+    assert event_name == "remove_overlay"
+
+    name_info = mock_send.call_args[0][0]["overlay_names"]
+    assert isinstance(name_info, list)
+    assert name_info[0] in overlay_names
+
+    if isinstance(overlay_names, list):
+        assert name_info == overlay_names

--- a/src/tests/test_overlay_manager.py
+++ b/src/tests/test_overlay_manager.py
@@ -1,0 +1,713 @@
+from astropy.table import Table
+from astropy.coordinates import SkyCoord, Angle
+import astropy.units as u
+import pytest
+from unittest.mock import Mock
+import warnings
+import re
+from typing import Callable, Iterable, Union
+
+from ipyaladin import Aladin
+from ipyaladin.overlays.overlay import Overlay, OverlayType
+from ipyaladin.elements.error_shape import EllipseError, CircleError
+from ipyaladin import Marker
+from regions import CircleSkyRegion
+from mocpy import MOC
+
+
+aladin = Aladin()
+aladin._is_loaded = True
+
+
+def test_overlay_manager_add_markers(
+    monkeypatch: Callable,
+) -> None:
+    """Test _overlay_manager overlay info from adding markers."""
+    mock_send = Mock()
+    monkeypatch.setattr(Aladin, "send", mock_send)
+
+    test_name = "test"
+    markers = []
+    for i in range(1, 11):
+        name = f"M{i}"
+        markers.append(
+            Marker(
+                position=name,
+                title=name,
+                description=(
+                    '<a href="https://simbad.cds.unistra.fr/simbad/'
+                    f'sim-basic?Ident={name}&submit=SIMBAD+search"> '
+                    "Read more on SIMBAD</a>"
+                ),
+            )
+        )
+    options = {"name": test_name, "color": "pink", "shape": "cross", "source_size": 15}
+
+    aladin.add_markers(
+        markers, name=test_name, color="pink", shape="cross", source_size=15
+    )
+
+    assert test_name in aladin._overlay_manager
+    assert aladin._overlay_manager[test_name]["type"] == "marker"
+    sent_message = mock_send.call_args[0][0]
+    assert sent_message["event_name"] == "add_marker"
+    assert sent_message["options"] == options
+
+    # test handling for a catalog with existing name
+    with warnings.catch_warnings(record=True) as w:
+        aladin.add_markers(
+            markers, name=test_name, color="pink", shape="cross", source_size=15
+        )
+        assert len(w) == 1
+        assert test_name + "_1" in str(w[-1].message)
+
+    assert test_name + "_1" in aladin._overlay_manager
+    assert aladin._overlay_manager[test_name + "_1"]["type"] == "marker"
+    sent_message = mock_send.call_args[0][0]
+    assert sent_message["event_name"] == "add_marker"
+    options["name"] = test_name + "_1"
+    assert sent_message["options"] == options
+
+    # test handling for catalog with no given name
+    options["name"] = "catalog"
+    aladin.add_markers(markers, color="pink", shape="cross", source_size=15)
+
+    assert "catalog" in aladin._overlay_manager
+    assert aladin._overlay_manager["catalog"]["type"] == "marker"
+    sent_message = mock_send.call_args[0][0]
+    assert sent_message["event_name"] == "add_marker"
+    assert sent_message["options"] == options
+
+    # test removing these overlays, resetting for next functionality check
+    aladin.remove_overlay([test_name, test_name + "_1", "catalog"])
+    assert not aladin._overlay_manager.keys()
+
+
+def test_overlay_manager_add_catalog_from_URL(
+    monkeypatch: Callable,
+) -> None:
+    """Test _overlay_manager overlay info from adding catalog using its URL."""
+    mock_send = Mock()
+    monkeypatch.setattr(Aladin, "send", mock_send)
+
+    test_name = "test"
+    url = (
+        "https://vizier.unistra.fr/viz-bin/votable?-source=HIP2&-c=LMC&-out.add=_RAJ,_"
+        "DEJ&-oc.form=dm&-out.meta=DhuL&-out.max=9999&-c.rm=180"
+    )
+    options = {
+        "source_size": 12,
+        "color": "#f08080",
+        "on_click": "showTable",
+        "name": test_name,
+    }
+    aladin.add_catalog_from_URL(url, options)
+
+    assert test_name in aladin._overlay_manager
+    assert aladin._overlay_manager[test_name]["type"] == "catalog"
+    sent_message = mock_send.call_args[0][0]
+    assert sent_message["event_name"] == "add_catalog_from_URL"
+    assert sent_message["votable_URL"] == url
+    assert sent_message["options"] == options
+
+    # test handling for a catalog with existing name
+    with warnings.catch_warnings(record=True) as w:
+        aladin.add_catalog_from_URL(url, options)
+        assert len(w) == 1
+        assert test_name + "_1" in str(w[-1].message)
+
+    assert test_name + "_1" in aladin._overlay_manager
+    assert aladin._overlay_manager[test_name + "_1"]["type"] == "catalog"
+    sent_message = mock_send.call_args[0][0]
+    assert sent_message["event_name"] == "add_catalog_from_URL"
+    assert sent_message["votable_URL"] == url
+    options["name"] = test_name + "_1"
+    assert sent_message["options"] == options
+
+    # test handling for catalog with no given name
+    options.pop("name")
+    aladin.add_catalog_from_URL(url, options)
+
+    assert "catalog" in aladin._overlay_manager
+    assert aladin._overlay_manager["catalog"]["type"] == "catalog"
+    sent_message = mock_send.call_args[0][0]
+    assert sent_message["event_name"] == "add_catalog_from_URL"
+    assert sent_message["votable_URL"] == url
+    options["name"] = "catalog"
+    assert sent_message["options"] == options
+
+    # test removing these overlays, resetting for next functionality check
+    aladin.remove_overlay([test_name, test_name + "_1", "catalog"])
+    assert not aladin._overlay_manager.keys()
+
+
+def test_overlay_manager_add_moc(monkeypatch: Callable) -> None:
+    """Test _overlay_manager overlay info from a moc."""
+    mock_send = Mock()
+    monkeypatch.setattr(Aladin, "send", mock_send)
+
+    test_name_url = "test_url"
+    test_name_dict = "test_dict"
+    test_name_moc = "test_moc"
+    moc_url = "https://fake_url.edu"
+    moc_dict = {"1": [1, 2, 4], "2": [12, 13, 14, 21, 23, 25]}
+    moc = MOC.from_ring(
+        lon=231.5855583 * u.deg,
+        lat=-57.03742777 * u.deg,
+        internal_radius=10 * u.deg,
+        external_radius=20 * u.deg,
+        max_depth=16,
+    )
+    options = {"name": test_name_url, "color": "pink", "opacity": 0.5}
+
+    # moc url call
+    aladin.add_moc(moc_url, **options)
+    sent_message = mock_send.call_args[0][0]
+    assert sent_message["event_name"] == "add_MOC_from_URL"
+
+    assert test_name_url in aladin._overlay_manager
+    assert aladin._overlay_manager[test_name_url]["type"] == "moc"
+    assert aladin._overlay_manager[test_name_url]["moc"] == moc_url
+
+    # moc dict call
+    aladin.add_moc(moc_dict, name=test_name_dict)
+    sent_message = mock_send.call_args[0][0]
+    assert sent_message["event_name"] == "add_MOC_from_dict"
+
+    assert test_name_dict in aladin._overlay_manager
+    assert aladin._overlay_manager[test_name_dict]["type"] == "moc"
+    assert aladin._overlay_manager[test_name_dict]["moc"] == moc_dict
+
+    # moc call
+    aladin.add_moc(moc, name=test_name_moc)
+    sent_message = mock_send.call_args[0][0]
+    assert sent_message["event_name"] == "add_MOC_from_dict"
+
+    assert test_name_moc in aladin._overlay_manager
+    assert aladin._overlay_manager[test_name_moc]["type"] == "moc"
+    assert aladin._overlay_manager[test_name_moc]["moc"] == moc.serialize("json")
+
+    # test handling for a moc with existing name
+    with warnings.catch_warnings(record=True) as w:
+        aladin.add_moc(moc_url, **options)
+        assert len(w) == 1
+        assert test_name_url + "_1" in str(w[-1].message)
+
+    assert test_name_url + "_1" in aladin._overlay_manager
+    assert aladin._overlay_manager[test_name_url + "_1"]["type"] == "moc"
+    sent_message = mock_send.call_args[0][0]
+    assert sent_message["event_name"] == "add_MOC_from_URL"
+    assert sent_message["moc_URL"] == moc_url
+    options["name"] = test_name_url + "_1"
+    assert sent_message["options"] == options
+
+    # test handling for catalog with no given name
+    options.pop("name")
+    aladin.add_moc(moc_url, **options)
+
+    assert "moc" in aladin._overlay_manager
+    assert aladin._overlay_manager["moc"]["type"] == "moc"
+    sent_message = mock_send.call_args[0][0]
+    assert sent_message["event_name"] == "add_MOC_from_URL"
+    assert sent_message["moc_URL"] == moc_url
+    options["name"] = "moc"
+    assert sent_message["options"] == options
+
+    # test removing these overlays, resetting for next functionality check
+    aladin.remove_overlay(
+        [
+            test_name_url,
+            test_name_dict,
+            test_name_moc,
+            test_name_url + "_1",
+            "moc",
+        ]
+    )
+    assert not aladin._overlay_manager.keys()
+
+
+def test_overlay_manager_add_table(monkeypatch: Callable) -> None:
+    """Test _overlay_manager overlay info from a table."""
+    mock_send = Mock()
+    monkeypatch.setattr(Aladin, "send", mock_send)
+
+    test_name = "test"
+    table = Table({"a": [1, 2, 3]})
+    table["a"].unit = "deg"
+
+    # normal table call
+    aladin.add_table(table, name=test_name)
+    sent_message = mock_send.call_args[0][0]
+    assert sent_message["event_name"] == "add_table"
+
+    assert test_name in aladin._overlay_manager
+    assert aladin._overlay_manager[test_name]["type"] == "table"
+    assert all(aladin._overlay_manager[test_name]["table"] == table)
+
+    # circle error
+    # test handling for an overlay with existing name
+    with warnings.catch_warnings(record=True) as w:
+        aladin.add_table(
+            table,
+            shape=CircleError(radius="a", default_shape="cross"),
+            color="pink",
+            name=test_name,
+        )
+        assert len(w) == 1
+        assert test_name + "_1" in str(w[-1].message)
+
+    sent_message = mock_send.call_args[0][0]
+    assert sent_message["options"]["circle_error"] == {
+        "radius": "a",
+        "conversion_radius": 1,
+    }
+    assert sent_message["options"]["shape"] == "cross"
+
+    assert test_name + "_1" in aladin._overlay_manager
+    assert aladin._overlay_manager[test_name + "_1"]["type"] == "table"
+    assert all(aladin._overlay_manager[test_name + "_1"]["table"] == table)
+    assert aladin._overlay_manager[test_name + "_1"]["options"]["color"] == "pink"
+    assert "circle_error" in aladin._overlay_manager[test_name + "_1"]["options"]
+
+    # ellipse error
+    aladin.add_table(table, shape=EllipseError(maj_axis="a", min_axis="a", angle="a"))
+    sent_message = mock_send.call_args[0][0]
+    ellipse_options = {
+        "maj_axis": "a",
+        "min_axis": "a",
+        "angle": "a",
+        "conversion_angle": 1,
+        "conversion_min_axis": 1,
+        "conversion_maj_axis": 1,
+    }
+    assert sent_message["options"]["ellipse_error"] == ellipse_options
+
+    assert "catalog" in aladin._overlay_manager
+    assert aladin._overlay_manager["catalog"]["type"] == "table"
+    assert all(aladin._overlay_manager["catalog"]["table"] == table)
+
+    # test removing these overlays, resetting for next functionality check
+    aladin.remove_overlay([test_name, test_name + "_1", "catalog"])
+    assert not aladin._overlay_manager.keys()
+
+
+def test_overlay_manager_add_graphic_overlay_from_region(
+    monkeypatch: Callable,
+) -> None:
+    """Test _overlay_manager overlay info from adding region overlay."""
+    mock_send = Mock()
+    monkeypatch.setattr(Aladin, "send", mock_send)
+
+    test_name = "test"
+    center = SkyCoord.from_name("M31")
+    radius = Angle(0.5, "deg")
+    circle = CircleSkyRegion(
+        center=center, radius=Angle(0.5, "deg"), visual={"edgecolor": "yellow"}
+    )
+    aladin.add_graphic_overlay_from_region([circle], name=test_name)
+
+    assert test_name in aladin._overlay_manager
+    assert aladin._overlay_manager[test_name]["type"] == "overlay_region"
+    regions_info = mock_send.call_args[0][0]["regions_infos"]
+    assert regions_info == aladin._overlay_manager[test_name]["regions_infos"]
+    assert regions_info[0]["infos"]["ra"] == center.ra.to_value(u.deg)
+    assert regions_info[0]["infos"]["dec"] == center.dec.to_value(u.deg)
+    assert regions_info[0]["infos"]["radius"] == radius.to_value(u.deg)
+
+    # test handling for an overlay with existing name
+    with warnings.catch_warnings(record=True) as w:
+        aladin.add_graphic_overlay_from_region([circle], name=test_name)
+        assert len(w) == 1
+        assert test_name + "_1" in str(w[-1].message)
+
+    assert test_name + "_1" in aladin._overlay_manager
+    assert aladin._overlay_manager[test_name + "_1"]["type"] == "overlay_region"
+    regions_info = mock_send.call_args[0][0]["regions_infos"]
+    assert regions_info == aladin._overlay_manager[test_name + "_1"]["regions_infos"]
+    assert regions_info[0]["infos"]["ra"] == center.ra.to_value(u.deg)
+    assert regions_info[0]["infos"]["dec"] == center.dec.to_value(u.deg)
+    assert regions_info[0]["infos"]["radius"] == radius.to_value(u.deg)
+
+    # test handling for overlay with no given name
+    aladin.add_graphic_overlay_from_region([circle])
+
+    assert "region" in aladin._overlay_manager
+    assert aladin._overlay_manager["region"]["type"] == "overlay_region"
+    regions_info = mock_send.call_args[0][0]["regions_infos"]
+    assert regions_info == aladin._overlay_manager["region"]["regions_infos"]
+    assert regions_info[0]["infos"]["ra"] == center.ra.to_value(u.deg)
+    assert regions_info[0]["infos"]["dec"] == center.dec.to_value(u.deg)
+    assert regions_info[0]["infos"]["radius"] == radius.to_value(u.deg)
+
+    # test removing these overlays, resetting for next functionality check
+    aladin.remove_overlay([test_name, test_name + "_1", "region"])
+    assert not aladin._overlay_manager.keys()
+
+
+def test_overlay_manager_add_graphic_overlay_from_stcs_(
+    monkeypatch: Callable,
+) -> None:
+    """Test _overlay_manager overlay info from adding iterable STC-S string(s)."""
+    mock_send = Mock()
+    monkeypatch.setattr(Aladin, "send", mock_send)
+
+    test_name = "test"
+    stcs_string = "CIRCLE ICRS 258.93205686 43.13632863 0.625"
+    aladin.add_graphic_overlay_from_stcs(stcs_string, name=test_name)
+
+    assert test_name in aladin._overlay_manager
+    assert aladin._overlay_manager[test_name]["type"] == "overlay_stcs"
+    regions_info = mock_send.call_args[0][0]["regions_infos"]
+    assert regions_info == aladin._overlay_manager[test_name]["regions_infos"]
+    assert regions_info[0]["infos"]["stcs"] in stcs_string
+
+    # test handling for an overlay with existing name
+    with warnings.catch_warnings(record=True) as w:
+        aladin.add_graphic_overlay_from_stcs(stcs_string, name=test_name)
+        assert len(w) == 1
+        assert test_name + "_1" in str(w[-1].message)
+
+    assert test_name + "_1" in aladin._overlay_manager
+    assert aladin._overlay_manager[test_name + "_1"]["type"] == "overlay_stcs"
+    regions_info = mock_send.call_args[0][0]["regions_infos"]
+    assert regions_info == aladin._overlay_manager[test_name + "_1"]["regions_infos"]
+    assert regions_info[0]["infos"]["stcs"] in stcs_string
+
+    # test handling for overlay with no given name
+    aladin.add_graphic_overlay_from_stcs(stcs_string)
+
+    assert "stcs_region" in aladin._overlay_manager
+    assert aladin._overlay_manager["stcs_region"]["type"] == "overlay_stcs"
+    regions_info = mock_send.call_args[0][0]["regions_infos"]
+    assert regions_info == aladin._overlay_manager["stcs_region"]["regions_infos"]
+    assert regions_info[0]["infos"]["stcs"] in stcs_string
+
+    # test removing these overlays, resetting for next functionality check
+    aladin.remove_overlay([test_name, test_name + "_1", "stcs_region"])
+    assert not aladin._overlay_manager.keys()
+
+
+def test_invalid_overlay_type(
+    monkeypatch: Callable,
+) -> None:
+    """Test proper error sent for adding invalid overlay type."""
+    mock_send = Mock()
+    monkeypatch.setattr(Aladin, "send", mock_send)
+
+    test_invalid_overlay = {"type": "not_valid", "options": {"name": "test_invalid"}}
+
+    # try creating invalid layer to confirm error is raised
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Invalid overlay type 'not_valid'. "
+            f"Must be one of {[t.value for t in OverlayType]}."
+        ),
+    ):
+        Overlay(test_invalid_overlay, aladin)
+
+
+def test_existing_overlay_name(
+    monkeypatch: Callable,
+) -> None:
+    """Test proper messages sent for existing overlays."""
+    test_name = "test"
+    mock_send = Mock()
+    monkeypatch.setattr(Aladin, "send", mock_send)
+
+    stcs_string = "CIRCLE ICRS 258.93205686 43.13632863 0.625"
+    aladin.add_graphic_overlay_from_stcs(stcs_string)
+    aladin.add_graphic_overlay_from_stcs(stcs_string, name=test_name)
+
+    # no name specified, no warning triggered
+    aladin.add_graphic_overlay_from_stcs(stcs_string)
+
+    # name specified, warning triggered
+    with pytest.warns(match="is already in use. Name `test_1`"):
+        aladin.add_graphic_overlay_from_stcs(stcs_string, name=test_name)
+
+    assert test_name in aladin._overlay_manager
+    assert "stcs_region" in aladin._overlay_manager
+    assert "stcs_region_1" in aladin._overlay_manager
+    expected_count = 4
+    assert len(aladin._overlay_manager.keys()) == expected_count
+
+
+test_marker_overlay = Overlay(
+    {"type": "marker", "options": {"name": "test_markers"}},
+    aladin,
+)
+
+
+test_catalog_overlay = Overlay(
+    {"type": "catalog", "options": {"name": "test_catalog"}},
+    aladin,
+)
+
+
+test_overlays = [
+    "overlay",
+    test_marker_overlay,
+    ["overlay", "overlay_1", "2MASS"],
+    "catalog",
+    ["overlay_1", "2MASS", test_catalog_overlay],
+]
+
+
+@pytest.mark.parametrize("overlays", test_overlays)
+def test_remove_overlay(
+    monkeypatch: Callable,
+    overlays: Union[Iterable[Union[str, Overlay]], str, Overlay],
+) -> None:
+    """Test proper messages sent for removing overlays.
+
+    Parameters
+    ----------
+    overlays : Union[Iterable[Union[str, Overlay]], str, Overlay]
+        The name strings of overlays.
+    """
+    mock_send = Mock()
+    monkeypatch.setattr(Aladin, "send", mock_send)
+
+    # generate expected _overlay_manager to remove names from
+    if isinstance(overlays, Overlay):
+        overlay_names = [overlays.name]
+    elif isinstance(overlays, str):
+        overlay_names = [overlays]
+    elif isinstance(overlays, (list, tuple)):
+        overlay_names = [o.name if isinstance(o, Overlay) else o for o in overlays]
+
+    aladin._overlay_manager = {name: {} for name in overlay_names}
+
+    aladin.remove_overlay(overlay_names)
+
+    event_name = mock_send.call_args[0][0]["event_name"]
+    assert isinstance(event_name, str)
+    assert event_name == "remove_overlay"
+
+    name_info = mock_send.call_args[0][0]["overlay_names"]
+    assert isinstance(name_info, list)
+    assert name_info[0] in overlay_names
+
+    if isinstance(overlay_names, list):
+        assert name_info == overlay_names
+
+    # confirm each overlay was removed from the dict as expected
+    assert not aladin._overlay_manager.keys()
+
+    # try removing non-existent layer to confirm error is raised
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"Cannot remove overlay `does_not_exist` since this layer does not exist."
+        ),
+    ):
+        aladin.remove_overlay("does_not_exist")
+
+
+def test_update_add_markers() -> None:
+    """Test update overlay info from adding markers."""
+    aladin = Aladin()
+    aladin._is_loaded = True
+
+    test_name = "test"
+
+    markers = []
+    for i in range(1, 11):
+        name = f"M{i}"
+        markers.append(
+            Marker(
+                position=name,
+                title=name,
+                description=(
+                    '<a href="https://simbad.cds.unistra.fr/simbad/'
+                    f'sim-basic?Ident={name}&submit=SIMBAD+search"> '
+                    "Read more on SIMBAD</a>"
+                ),
+            )
+        )
+    options = {"name": test_name, "color": "pink", "shape": "cross", "source_size": 15}
+    marker_overlay = aladin.add_markers(markers, **options)
+
+    assert type(marker_overlay) is Overlay
+    assert marker_overlay.options == options
+
+    updated_options = options.copy()
+    updated_options.update(
+        {"name": test_name + "_1", "color": "red", "shape": "random", "source_size": 20}
+    )
+
+    marker_overlay = marker_overlay.update(**updated_options)
+
+    assert test_name not in aladin._overlay_manager
+    assert test_name + "_1" in aladin._overlay_manager
+    assert marker_overlay.name == updated_options["name"]
+    assert marker_overlay.options == updated_options
+
+
+def test_update_add_catalog_from_URL() -> None:
+    """Test update overlay info from adding catalog using its URL."""
+    aladin = Aladin()
+    aladin._is_loaded = True
+
+    test_name = "test"
+
+    url = (
+        "https://vizier.unistra.fr/viz-bin/votable?-source=HIP2&-c=LMC&-out.add=_RAJ,_"
+        "DEJ&-oc.form=dm&-out.meta=DhuL&-out.max=9999&-c.rm=180"
+    )
+    options = {
+        "source_size": 12,
+        "color": "#f08080",
+        "on_click": "showTable",
+        "name": test_name,
+    }
+    url_overlay = aladin.add_catalog_from_URL(url, options)
+
+    assert type(url_overlay) is Overlay
+    assert url_overlay.options == options
+
+    updated_options = options.copy()
+    updated_options.update(
+        {"name": test_name + "_1", "color": "#66FF00", "source_size": 20}
+    )
+
+    url_overlay = url_overlay.update(**updated_options)
+
+    assert test_name not in aladin._overlay_manager
+    assert test_name + "_1" in aladin._overlay_manager
+    assert url_overlay.name == updated_options["name"]
+    assert url_overlay.options == updated_options
+
+
+test_mocs = [
+    "https://fake_url.edu",
+    {"1": [1, 2, 4], "2": [12, 13, 14, 21, 23, 25]},
+    MOC.from_ring(
+        lon=231.5855583 * u.deg,
+        lat=-57.03742777 * u.deg,
+        internal_radius=10 * u.deg,
+        external_radius=20 * u.deg,
+        max_depth=16,
+    ),
+]
+
+
+@pytest.mark.parametrize("moc", test_mocs)
+def test_update_add_moc(
+    moc: Union[MOC, str, dict],
+) -> None:
+    """Test update overlay info from adding moc."""
+    aladin = Aladin()
+    aladin._is_loaded = True
+
+    test_name = "test"
+    options = {"name": test_name, "color": "pink", "opacity": 0.5}
+
+    moc_overlay = aladin.add_moc(moc, **options)
+    assert type(moc_overlay) is Overlay
+    assert moc_overlay.options == options
+
+    updated_options = options.copy()
+    updated_options.update(
+        {"name": test_name + "_1", "color": "#00F7FF", "opacity": 0.3}
+    )
+
+    moc_overlay = moc_overlay.update(**updated_options)
+
+    assert test_name not in aladin._overlay_manager
+    assert test_name + "_1" in aladin._overlay_manager
+    assert moc_overlay.name == updated_options["name"]
+    assert moc_overlay.options == updated_options
+
+
+def test_update_add_table() -> None:
+    """Test update overlay info from a table."""
+    aladin = Aladin()
+    aladin._is_loaded = True
+
+    test_name = "test"
+    table = Table({"a": [1, 2, 3]})
+    table["a"].unit = "deg"
+
+    options = {
+        "color": "pink",
+        "name": test_name,
+        "circle_error": {"radius": "a", "conversion_radius": 1},
+    }
+    table_overlay = aladin.add_table(
+        table,
+        shape=CircleError(radius="a", default_shape="cross"),
+        **options,
+    )
+    options["shape"] = "cross"
+
+    assert type(table_overlay) is Overlay
+    assert table_overlay.options == options
+
+    options.pop("shape")
+    updated_options = options.copy()
+    updated_options.update({"name": test_name + "_1"})
+
+    table_overlay = table_overlay.update(**updated_options)
+    updated_options["shape"] = "cross"
+
+    assert test_name not in aladin._overlay_manager
+    assert test_name + "_1" in aladin._overlay_manager
+    assert table_overlay.name == updated_options["name"]
+    assert table_overlay.options == updated_options
+
+
+def test_update_add_graphic_overlay_from_region() -> None:
+    """Test update overlay info from adding region overlay."""
+    aladin = Aladin()
+    aladin._is_loaded = True
+
+    test_name = "test"
+
+    circle = CircleSkyRegion(
+        center=SkyCoord.from_name("M31"),
+        radius=Angle(0.5, "deg"),
+        visual={"edgecolor": "yellow"},
+    )
+    options = {"name": test_name}
+    region_overlay = aladin.add_graphic_overlay_from_region([circle], **options)
+
+    assert type(region_overlay) is Overlay
+    assert region_overlay.options == options
+
+    updated_options = options.copy()
+    updated_options.update({"name": test_name + "_1", "color": "#66FF00"})
+
+    region_overlay = region_overlay.update(**updated_options)
+
+    assert test_name not in aladin._overlay_manager
+    assert test_name + "_1" in aladin._overlay_manager
+    assert region_overlay.name == updated_options["name"]
+    assert region_overlay.options["color"] == updated_options["color"]
+    assert region_overlay.options == updated_options
+
+
+def test_update_add_graphic_overlay_from_stcs_() -> None:
+    """Test update overlay info from adding iterable STC-S string(s)."""
+    aladin = Aladin()
+    aladin._is_loaded = True
+
+    stcs_strings = "CIRCLE ICRS 258.93205686 43.13632863 0.625"
+    test_name = "test"
+    options = {"name": test_name, "color": "red"}
+    stcs_overlay = aladin.add_graphic_overlay_from_stcs(stcs_strings, **options)
+
+    assert type(stcs_overlay) is Overlay
+    assert stcs_overlay.options == options
+
+    updated_options = options.copy()
+    updated_options.update({"name": test_name + "_1", "color": "#66FF00"})
+
+    stcs_overlay = stcs_overlay.update(**updated_options)
+
+    assert test_name not in aladin._overlay_manager
+    assert test_name + "_1" in aladin._overlay_manager
+    assert stcs_overlay.name == updated_options["name"]
+    assert stcs_overlay.options["color"] == updated_options["color"]
+    assert stcs_overlay.options == updated_options


### PR DESCRIPTION
This implements an overlay manager that tracks the overlays users add to and remove from the widget through both the GUI and API.

Each overlay is given a unique name (following the convention used by aladin-lite), and the information used to create that overlay is stored in a dictionary. This allows users manage overlays from both the GUI and API while maintaining a synced understanding of layers across the two interfaces (enabled by `stackChanged` https://github.com/cds-astro/aladin-lite/issues/338) . Overlays added via the GUI are tracked by the overlay manager, though they are not update-able via the API at present. Each overlay is an instance of the class `Overlay`, which allows for easier handling and interactions. 

A quick video demonstrating basic functionality is below:

https://github.com/user-attachments/assets/285f200e-63e0-4c8f-9eca-d68e1a6a98f1


If helpful I can also share (or include in this PR) a more comprehensive notebook that I created for testing the functionality.