### PR TITLE
Correct parameter formatting in widget.py

### DIFF
--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -892,8 +892,8 @@ class Aladin(anywidget.AnyWidget):
         Parameters
         ----------
         region: `~regions.CircleSkyRegion`, `~regions.EllipseSkyRegion`,
-        `~regions.LineSkyRegion`,`~regions.PolygonSkyRegion`,
-        `~regions.RectangleSkyRegion`, `~regions.Regions`, or a list of these.
+                `~regions.LineSkyRegion`,`~regions.PolygonSkyRegion`,
+                `~regions.RectangleSkyRegion`, `~regions.Regions`, or a list of these.
             The region(s) to add in Aladin Lite. It can be given as a supported region
             or a list of regions from the
             `regions package <https://astropy-regions.readthedocs.io>`_.


### PR DESCRIPTION
Sphinx doc builds raise two warnings and an error on these lines.

I ran the docs build and verified that the warnings and error go away.